### PR TITLE
Adding kube Prometheus stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ As part of the project the goal is to deploy on the Kuberenets cluster basic ser
         - [SSL certificates centralized management](documentation/certmanager.md). Configure Cert-manager to automatically manage the lifecycle of SSL certificates.
     - [K3S Distributed Storage](documentation/longhorn.md). Installing LongHorn as cluster distributed storage solution for providing Persistent Volumes to pods.
     - [K3S centralized logging monitoring](documentation/logging.md). Installing a centralized log monitoring tool based on EFK stack. Real-time processing of Kuberentes pods and services and homelab servers logs.
+    - [K3S centralized monitoring](documentation/monitoring.md). Installing Kube Prometheus Stack for monitoring Kuberentes cluster
 
 ## About the Project
 

--- a/ansible/k3s_deploy.yml
+++ b/ansible/k3s_deploy.yml
@@ -35,6 +35,8 @@
       tags: ['certmanager']
     - role: longhorn
       tags: ['longhorn']
+    - role: prometheus
+      tags: ['monitoring']
     - role: logging/k3s
       tags: ['logging']
 

--- a/ansible/roles/longhorn/tasks/main.yml
+++ b/ansible/roles/longhorn/tasks/main.yml
@@ -15,7 +15,7 @@
   kubernetes.core.helm:
     name: longhorn
     chart_ref: longhorn/longhorn
-    # chart_version: "2.0.7"
+    update_repo_cache: true
     release_namespace: longhorn-system
     state: present
     release_values:

--- a/ansible/roles/prometheus/defaults/main.yml
+++ b/ansible/roles/prometheus/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+# Storage Settings
+prometheus_storage_size: "5Gi"
+prometheus_storage_class: "longhorn"

--- a/ansible/roles/prometheus/tasks/main.yml
+++ b/ansible/roles/prometheus/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+- name: Create prometheus namespace.
+  kubernetes.core.k8s:
+    name: k3s-monitoring
+    api_version: v1
+    kind: Namespace
+    state: present
+
+- name: Add prometheus community chart repo.
+  kubernetes.core.helm_repository:
+    name: prometheus-community
+    repo_url: "https://prometheus-community.github.io/helm-charts"
+
+- name: Deploy prometheus-stack Helm chart.
+  kubernetes.core.helm:
+    name: kube-prometheus-stack
+    chart_ref: prometheus-community/kube-prometheus-stack
+    release_namespace: k3s-monitoring
+    state: present
+    release_values:
+      alertmanager:
+        alertmanagerSpec:
+          storage:
+            volumeClaimTemplate:
+              spec:
+                storageClassName: "{{ prometheus_storage_class }}"
+                accessModes: ["ReadWriteOnce"]
+                resources:
+                  requests:
+                    storage: "{{ prometheus_storage_size }}"
+                # selector: {}
+      prometheus:
+        prometheusSpec:
+          storageSpec:
+            volumeClaimTemplate:
+              spec:
+                storageClassName: "{{ prometheus_storage_class }}"
+                accessModes: ["ReadWriteOnce"]
+                resources:
+                  requests:
+                    storage: "{{ prometheus_storage_size }}"
+                # selector: {}
+- name: Create Ingress rule for Prometheus, Alertmanager and Graphana UI
+  kubernetes.core.k8s:
+    definition: "{{ lookup('template', 'templates/' + item ) }}"
+    state: present
+  with_items:
+    - prometheus_ingress.yml
+

--- a/ansible/roles/prometheus/tasks/main.yml
+++ b/ansible/roles/prometheus/tasks/main.yml
@@ -28,7 +28,6 @@
                 resources:
                   requests:
                     storage: "{{ prometheus_storage_size }}"
-                # selector: {}
       prometheus:
         prometheusSpec:
           storageSpec:
@@ -39,11 +38,12 @@
                 resources:
                   requests:
                     storage: "{{ prometheus_storage_size }}"
-                # selector: {}
+
 - name: Create Ingress rule for Prometheus, Alertmanager and Graphana UI
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'templates/' + item ) }}"
     state: present
   with_items:
     - prometheus_ingress.yml
-
+    - grafana_ingress.yml
+    - alertmanager_ingress.yml

--- a/ansible/roles/prometheus/templates/alertmanager_ingress.yml
+++ b/ansible/roles/prometheus/templates/alertmanager_ingress.yml
@@ -1,0 +1,58 @@
+---
+# HTTPS Ingress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: alertmanager-ingress
+  namespace: k3s-monitoring
+  annotations:
+    # HTTPS as entry point
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    # Enable TLS
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    # Use Basic Auth Midleware configured
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-system-basic-auth@kubernetescrd
+    # Enable cert-manager to create automatically the SSL certificate and store in Secret
+    cert-manager.io/cluster-issuer: self-signed-issuer
+    cert-manager.io/common-name: alertmanager
+spec:
+  tls:
+  - hosts:
+    - alertmanager.picluster.ricsanfre.com
+    secretName: prometheus-tls
+  rules:
+  - host: alertmanager.picluster.ricsanfre.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: kube-prometheus-stack-alertmanager
+            port:
+              number: 9093
+
+---
+# http ingress for http->https redirection
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: alertmanager-redirect
+  namespace: k3s-monitoring
+  annotations:
+    # Use redirect Midleware configured
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-system-redirect@kubernetescrd
+    # HTTP as entrypoint
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  rules:
+    - host: alertmanager.picluster.ricsanfre.com
+      http:
+        paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: kube-prometheus-stack-alertmanager
+              port:
+                number: 9093

--- a/ansible/roles/prometheus/templates/grafana_ingress.yml
+++ b/ansible/roles/prometheus/templates/grafana_ingress.yml
@@ -1,0 +1,56 @@
+---
+# HTTPS Ingress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana-ingress
+  namespace: k3s-monitoring
+  annotations:
+    # HTTPS as entry point
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    # Enable TLS
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    # Enable cert-manager to create automatically the SSL certificate and store in Secret
+    cert-manager.io/cluster-issuer: self-signed-issuer
+    cert-manager.io/common-name: grafana
+spec:
+  tls:
+  - hosts:
+    - grafana.picluster.ricsanfre.com
+    secretName: grafana-tls
+  rules:
+  - host: grafana.picluster.ricsanfre.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: kube-prometheus-stack-grafana
+            port:
+              number: 80
+
+---
+# http ingress for http->https redirection
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: grafana-redirect
+  namespace: k3s-monitoring
+  annotations:
+    # Use redirect Midleware configured
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-system-redirect@kubernetescrd
+    # HTTP as entrypoint
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  rules:
+    - host: grafana.picluster.ricsanfre.com
+      http:
+        paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: kube-prometheus-stack-grafana
+              port:
+                number: 80

--- a/ansible/roles/prometheus/templates/prometheus_ingress.yml
+++ b/ansible/roles/prometheus/templates/prometheus_ingress.yml
@@ -1,0 +1,58 @@
+---
+# HTTPS Ingress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prometheus-ingress
+  namespace: k3s-monitoring
+  annotations:
+    # HTTPS as entry point
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    # Enable TLS
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    # Use Basic Auth Midleware configured
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-system-basic-auth@kubernetescrd
+    # Enable cert-manager to create automatically the SSL certificate and store in Secret
+    cert-manager.io/cluster-issuer: self-signed-issuer
+    cert-manager.io/common-name: prometheus
+spec:
+  tls:
+  - hosts:
+    - prometheus.picluster.ricsanfre.com
+    secretName: prometheus-tls
+  rules:
+  - host: prometheus.picluster.ricsanfre.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: kube-prometheus-stack-prometheus
+            port:
+              number: 9090
+
+---
+# http ingress for http->https redirection
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: prometheus-redirect
+  namespace: k3s-monitoring
+  annotations:
+    # Use redirect Midleware configured
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-system-redirect@kubernetescrd
+    # HTTP as entrypoint
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  rules:
+    - host: prometheus.picluster.ricsanfre.com
+      http:
+        paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: kube-prometheus-stack-prometheus
+              port:
+                number: 9090

--- a/documentation/monitoring.md
+++ b/documentation/monitoring.md
@@ -198,7 +198,7 @@ spec:
                 number: 80
 
 ```
-- Step 2. Create a manifest file `alertmanager_ingress.yml`
+- Step 3. Create a manifest file `alertmanager_ingress.yml`
 
 Two Ingress resources will be created, one for HTTP and other for HTTPS. Traefik middlewares HTTPS redirect will be used
 
@@ -261,6 +261,6 @@ spec:
                 number: 9093
 
 ``` 
-- Step 3. Apply the manifest file
+- Step 4. Apply the manifest file
 
-    kubectl apply -f prometheus_ingress.yml grafana_ingress.yml
+    kubectl apply -f prometheus_ingress.yml grafana_ingress.yml alertmanager_ingress.yml

--- a/documentation/monitoring.md
+++ b/documentation/monitoring.md
@@ -1,0 +1,38 @@
+# Centralized Monitoring with Prometheus
+
+Prometheus stack installation for kubernetes using Prometheus Operator can be streamlined using [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus) project maintaned by the community.
+
+This project collects Kubernetes manifests, Grafana dashboards, and Prometheus rules combined with documentation and scripts to provide easy to operate end-to-end Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.
+
+Components included in this package:
+
+- The Prometheus Operator
+- Highly available Prometheus
+- Highly available Alertmanager
+- Prometheus node-exporter
+- Prometheus Adapter for Kubernetes Metrics APIs
+- kube-state-metrics
+- Grafana
+
+This stack is meant for cluster monitoring, so it is pre-configured to collect metrics from all Kubernetes components.
+
+## Kube-Prometheus Stack installation
+
+Kube-prometheus stack can be installed using helm [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) maintaind by the community
+
+- Step 1: Add the Elastic repository:
+    ```
+    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+    ```
+- Step2: Fetch the latest charts from the repository:
+    ```
+    helm repo update
+    ```
+- Step 3: Create namespace
+    ```
+    kubectl create namespace monitoring
+    ```
+- Step 3: Install kube-Prometheus-stack in the monitoring namespace
+    ```
+    helm install kube-prometheus-stack prometheus-community/kube-prometheus-stack --namespace monitoring
+    ```


### PR DESCRIPTION
# Deploy kube prometheus stack

Deploy [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus) stack based on Prometheus Operator using community-maintained helm chart [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack).

This Helm deploy the following components:
* The [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator)
*  Highly available [Prometheus](https://prometheus.io/)
*  Highly available [Alertmanager](https://github.com/prometheus/alertmanager)
*  [Prometheus node-exporter](https://github.com/prometheus/node_exporter)
*  [Prometheus Adapter for Kubernetes Metrics APIs](https://github.com/DirectXMan12/k8s-prometheus-adapter) 
*  [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics)
*  [Grafana](https://grafana.com/)


## Issues fixed by this PR:
- Fix #2 