### PR TITLE
Ansible playbooks refactoring for solving ansible-lint issues

### DIFF
--- a/ansible/roles/basic_setup/tasks/main.yaml
+++ b/ansible/roles/basic_setup/tasks/main.yaml
@@ -37,4 +37,5 @@
     path: /boot/firmware/config.txt
     line: "gpu_mem=16"
     create: true
+    mode: 0755
   notify: reboot

--- a/ansible/roles/k3s/master/tasks/main.yml
+++ b/ansible/roles/k3s/master/tasks/main.yml
@@ -1,8 +1,16 @@
 ---
 
+- name: Get K3s installation script
+  get_url:
+    url: https://get.k3s.io
+    dest: /tmp/k3s_install.sh
+    mode: '0766'
+
 - name: Install K3s
-  shell:
-    cmd: "curl -sfL https://get.k3s.io | K3S_TOKEN={{ k3s_token }} sh -s - server {{ k3s_server_extra_args }}"
+  command: "/tmp/k3s_install.sh server {{ k3s_server_extra_args }}"
+  environment:
+    K3S_TOKEN: "{{ k3s_token }}"
+  changed_when: true
 
 - name: Create directory .kube
   file:

--- a/ansible/roles/k3s/worker/tasks/main.yml
+++ b/ansible/roles/k3s/worker/tasks/main.yml
@@ -1,5 +1,14 @@
 ---
 
+- name: Get K3s installation script
+  get_url:
+    url: https://get.k3s.io
+    dest: /tmp/k3s_install.sh
+    mode: '0766'
+
 - name: Install K3s
-  shell:
-    cmd: "curl -sfL https://get.k3s.io | K3S_URL='https://{{ k3s_master_ip }}:6443' K3S_TOKEN={{ k3s_token }} sh -s - {{ k3s_worker_extra_args }}"
+  command: "/tmp/k3s_install.sh {{ k3s_worker_extra_args }}"
+  environment:
+    K3S_TOKEN: "{{ k3s_token }}"
+    K3S_URL: "https://{{ k3s_master_ip }}:6443"
+  changed_when: true

--- a/ansible/roles/longhorn/tasks/main.yml
+++ b/ansible/roles/longhorn/tasks/main.yml
@@ -29,8 +29,13 @@
   with_items:
     - longhorn_ingress.yml.j2
 
-- name: Remove Local-Path as default storage class
-  command:
-    cmd: >
-     kubectl patch storageclass local-path -p
-     '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+- name: Patching Local-path storage resource. Set it as non-default
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: v1
+      kind: StorageClass
+      metadata:
+        name: local-path
+        annotations:
+          storageclass.kubernetes.io/is-default-class: "false"
+      state: present

--- a/ansible/roles/traefik/tasks/create_basic_auth_credentials.yml
+++ b/ansible/roles/traefik/tasks/create_basic_auth_credentials.yml
@@ -12,6 +12,7 @@
     cmd: >-
       htpasswd -nb {{ traefik_basic_auth_user }} {{ traefik_basic_auth_passwd }} | base64
   register: htpasswd
+  changed_when: false
 
 - name: Set htpasswd pair
   set_fact:

--- a/ansible/tasks/cleaning.yml
+++ b/ansible/tasks/cleaning.yml
@@ -1,30 +1,50 @@
 ---
-- name: Clean Longhorn storage
-  shell: "rm -rf /storage/*"
-  args:
-    executable: /bin/bash
-  changed_when: true
+
+- name: Clean Longhorn storage | get content
+  become: true
+  find:
+    paths: /storage
+    patterns: '*'
+    file_type: any
+    hidden: true
+  register: directory_content_result
+
+- name: Clean Longhorn storage | delete content
+  become: true
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: "{{ directory_content_result.files }}"
 
 - name: Clean longhorn iscsi targets and nodes
   shell: |
+    set -o pipefail
     for i in `sudo iscsiadm -m discovery -o show | grep -v 10.0.0.1 | awk '{print $1}'`
     do
     echo "Deleting target $i"
     sudo iscsiadm -m discovery -p $i -o delete
     done
+  args:
+    executable: /bin/bash
   register: output
   changed_when: true
 
 - name: Clean container/pod logs
-  shell: "rm -rf /var/log/pods /var/log/containers"
-  args:
-    executable: /bin/bash
-  ignore_errors: true
-  changed_when: true
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "/var/log/pods"
+    - "/var/log/containers"
 
-- name: Clean fluentd pos files
-  shell: "rm /var/log/*.pos"
-  args:
-    executable: /bin/bash
-  ignore_errors: true
-  changed_when: true
+- name: Clean fluentd pos files | get pos files
+  find:
+    paths: /var/log
+    patterns: '*.pos'
+  register: files_to_delete
+
+- name: Clean fluentd pos files | delete pos files
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: "{{ files_to_delete.files }}"


### PR DESCRIPTION

Refactoring some ansible tasks to solve all ansible-lint issues:

- Cleaning tasks in k3s_reset.yml playbook. Replace cleaning tasks using `rm` shell commands by ansible module `file`
- Installation K3S, replacing use of `curl` shell command by `get_url` ansible module
- Longhorn installation: replace patching kubernetes resource, kubectl patch command, by k8s ansible module
- Other minor changes.