### PR TITLE
Reword "rebuild automatically" to "automatically rebuild"

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -58,7 +58,7 @@ last_modified_at: "05-04-2022"
         </div>
         <div class="col-sm-4">
             <h2 class="text-center"><i class="fas fa-cogs" aria-hidden="true"></i></h2>
-            <h5 class="text-center">Rebuild automatically the cluster</h5>
+            <h5 class="text-center">Automatically rebuild the cluster</h5>
             <p>You can break the cluster configuration as many times as you need during your testing/learning process and be able to rebuild the cluster in minutes.
             All installation/configuration activities are automated with Ansible. 
             It also makes easy to re-configure cluster nodes in case of hardware failure</p>


### PR DESCRIPTION
Reword "rebuild automatically" to "automatically rebuild". This word order makes more sense in English, hope you agree :)