### PR TITLE
Migrate external services (S3 backup/Vault) outside cluster and deploy Minio cluster service for Loki/Tempo

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Even whe the premise is to deploy all services in the kubernetes cluster, there 
 
 ### Self-hosted external services 
 
-There is another list of services that I have decided to run outside the kuberentes cluster but not using any cloud service. These services currently are running on the same cluster nodes (gateway and node1), but as baremetal service.
+There is another list of services that I have decided to run outside the kuberentes cluster selfhosting them on VMs running in Public Cloud, using [Oracle Cloud Infrastructure (OCI) free tier](https://www.oracle.com/es/cloud/free/).
 
 |  |External Service | Resource | Purpose |
 | --- | --- | --- | --- |

--- a/ansible/external_services.yml
+++ b/ansible/external_services.yml
@@ -136,7 +136,7 @@
 ## Install Hashicorp Vault Server
 
 - name: Install Vault Server
-  hosts: gateway
+  hosts: vault
   gather_facts: true
   tags: [vault]
   become: true
@@ -223,7 +223,7 @@
 
 ## Load all credentials into Hashicorp Vault Server
 - name: Load Vault Credentials
-  hosts: gateway
+  hosts: vault
   gather_facts: true
   tags: [vault, credentials]
   become: false

--- a/ansible/external_services.yml
+++ b/ansible/external_services.yml
@@ -83,7 +83,7 @@
 ## Install Minio S3 Storage Server
 
 - name: Install Minio S3 Storage Server
-  hosts: node1
+  hosts: s3
   gather_facts: true
   tags: [s3]
   become: true

--- a/ansible/group_vars/external.yml
+++ b/ansible/group_vars/external.yml
@@ -1,2 +1,3 @@
+---
 # Remote user name
 ansible_user: ubuntu

--- a/ansible/group_vars/external.yml
+++ b/ansible/group_vars/external.yml
@@ -1,0 +1,2 @@
+# Remote user name
+ansible_user: ubuntu

--- a/ansible/host_vars/gateway.yml
+++ b/ansible/host_vars/gateway.yml
@@ -55,12 +55,12 @@ ntp_allow_hosts: [10.0.0.0/24]
 # firewall role variables
 #########################
 
-# tcp 8200, 8201 Vault server
 # tcp 9100 Prometheus (fluent-bit)
-in_tcp_port: '{ ssh, https, http, iscsi-target, 9100, 8200, 8201 }'
+in_tcp_port: '{ ssh, https, http, iscsi-target, 9100 }'
 in_udp_port: '{ snmp, domain, ntp, bootps }'
 # tcp 9091 minio server
-forward_tcp_port: '{ http, https, ssh, 9091 }'
+# tcp 8200, 8201 Vault server
+forward_tcp_port: '{ http, https, ssh, 9091, 8200, 8201 }'
 forward_udp_port: '{ domain, ntp }'
 # Enabling forwarding and NAT
 firewall_forward_enabled: true
@@ -117,8 +117,8 @@ nft_forward_host_rules:
     - iifname $wan_interface oifname $lan_interface ip daddr $lan_network tcp dport ssh ct state new accept
   230 http from wan:
     - iifname $wan_interface oifname $lan_interface ip daddr $lan_network tcp dport {http, https} ct state new accept
-  240 s3 from wan:
-    - iifname $wan_interface oifname $lan_interface ip daddr 10.0.0.11 tcp dport {9091, 9092} ct state new accept
+  240 kube-api from wan:
+    - iifname $wan_interface oifname $lan_interface ip daddr 10.0.0.11 tcp dport 6443 ct state new accept
   250 port-forwarding from wan:
     - iifname $wan_interface oifname $lan_interface ip daddr 10.0.0.11 tcp dport 8080 ct state new accept
 # NAT Post-routing

--- a/ansible/host_vars/gateway.yml
+++ b/ansible/host_vars/gateway.yml
@@ -59,7 +59,8 @@ ntp_allow_hosts: [10.0.0.0/24]
 # tcp 9100 Prometheus (fluent-bit)
 in_tcp_port: '{ ssh, https, http, iscsi-target, 9100, 8200, 8201 }'
 in_udp_port: '{ snmp, domain, ntp, bootps }'
-forward_tcp_port: '{ http, https, ssh }'
+# tcp 9091 minio server
+forward_tcp_port: '{ http, https, ssh, 9091 }'
 forward_udp_port: '{ domain, ntp }'
 # Enabling forwarding and NAT
 firewall_forward_enabled: true

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -14,6 +14,11 @@ all:
           ansible_connection: local
           ip: 10.0.0.10
           mac: 08:00:27:f3:6b:dd
+    external:
+      hosts:
+        s3:
+          hostname: s3
+          ansible_host: s3.ricsanfre.com
     picluster:
       hosts:
         node1:

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -19,6 +19,9 @@ all:
         s3:
           hostname: s3
           ansible_host: s3.ricsanfre.com
+        vault:
+          hostname: vault
+          ansible_host: vault.ricsanfre.com
     picluster:
       hosts:
         node1:

--- a/ansible/reset_external_services.yml
+++ b/ansible/reset_external_services.yml
@@ -1,6 +1,6 @@
 ---
 - name: Clean Minio Installation
-  hosts: node1
+  hosts: s3
   become: true
   gather_facts: false
   tags: [s3]
@@ -27,7 +27,7 @@
         daemon_reload: true
 
 - name: Clean Vault Installation
-  hosts: gateway
+  hosts: vault
   become: true
   gather_facts: false
   tags: [vault]

--- a/ansible/tasks/create_minio_bearer_token.yml
+++ b/ansible/tasks/create_minio_bearer_token.yml
@@ -1,12 +1,12 @@
 ---
 # Minio prometheus bearer token was created and stored in filesystem
-- name: Load prometheus bearer token from file in node1
+- name: Load prometheus bearer token from file in vault node
   command: "jq -r '.bearerToken' /etc/minio/prometheus_bearer.json"
   register: root_token
   become: true
   changed_when: false
   when: minio_prom_bearer_token is not defined
-  delegate_to: node1
+  delegate_to: vault
 
 - name: Get bearer token
   set_fact:

--- a/ansible/tasks/vault_kubernetes_auth_method_config.yml
+++ b/ansible/tasks/vault_kubernetes_auth_method_config.yml
@@ -18,7 +18,7 @@
   become: false
   register: vault_login
   changed_when: false
-  delegate_to: gateway
+  delegate_to: vault
 
 - name: Get vault token
   set_fact:

--- a/ansible/vars/picluster.yml
+++ b/ansible/vars/picluster.yml
@@ -201,8 +201,7 @@ restic_environment:
 # Vault configuration
 #######################
 
-vault_hostname: "vault.{{ dns_domain }}"
-vault_address: 10.0.0.1
+vault_hostname: "vault.ricsanfre.com"
 vault_dns: "{{ vault_hostname }}"
 vault_enable_tls: true
 custom_ca: false

--- a/ansible/vars/picluster.yml
+++ b/ansible/vars/picluster.yml
@@ -82,7 +82,7 @@ acme_issuer_email: admin@ricsanfre.com
 ##########################
 
 # Minio S3 Server
-minio_hostname: "s3.{{ dns_domain }}"
+minio_hostname: "s3.ricsanfre.com"
 minio_endpoint: "{{ minio_hostname }}:9091"
 minio_url: "https://{{ minio_hostname }}:9091"
 

--- a/argocd/bootstrap/root/values.yaml
+++ b/argocd/bootstrap/root/values.yaml
@@ -52,6 +52,11 @@ apps:
     namespace: longhorn-system
     path: argocd/system/longhorn-system
     syncWave: 5
+    # Minio Object Storage
+  - name: minio
+    namespace: minio
+    path: argocd/system/minio
+    syncWave: 5
     # Velero Backup
   - name: velero
     namespace: velero

--- a/argocd/system/external-secrets/values.yaml
+++ b/argocd/system/external-secrets/values.yaml
@@ -2,7 +2,7 @@
 # Vault secret store
 vault:
   # Vault server URL
-  vaultUrl: "https://vault.picluster.ricsanfre.com:8200"
+  vaultUrl: "https://vault.ricsanfre.com:8200"
 
   # Vault CA cert
   # caBundle needed if vault TLS is signed using a custom CA.

--- a/argocd/system/logging/values.yaml
+++ b/argocd/system/logging/values.yaml
@@ -193,6 +193,10 @@ fluentd:
   rbac:
     create: false
 
+  # Do not create pod service policy (from removed kubernetes 1.25)
+  podSecurityPolicy:
+    enabled: false
+
   ## Additional environment variables to set for fluentd pods
   env:
     # Path to fluentd conf file

--- a/argocd/system/logging/values.yaml
+++ b/argocd/system/logging/values.yaml
@@ -77,12 +77,11 @@ loki:
         ruler: k3s-loki
       type: s3
       s3:
-        endpoint: s3.picluster.ricsanfre.com:9091
-        region: eu-west-1
+        endpoint: minio.minio:9000
         secretAccessKey: ${MINIO_SECRET_ACCESS_KEY}
         accessKeyId: ${MINIO_ACCESS_KEY_ID}
         s3ForcePathStyle: true
-        insecure: false
+        insecure: true
         http_config:
           idle_conn_timeout: 90s
           response_header_timeout: 0s

--- a/argocd/system/longhorn-system/values.yaml
+++ b/argocd/system/longhorn-system/values.yaml
@@ -15,7 +15,7 @@ ingress:
 
 # Backup S3 backend URL
 backup:
-  minioUrl: "https://s3.picluster.ricsanfre.com:9091"
+  minioUrl: "https://s3.ricsanfre.com:9091"
 
 # Prometheus servicemonitor configuration
 serviceMonitor:

--- a/argocd/system/minio/Chart.yaml
+++ b/argocd/system/minio/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: minio
+version: 0.0.0
+dependencies:
+  - name: minio
+    version: 5.0.7
+    repository: https://charts.min.io/

--- a/argocd/system/minio/templates/ingress.yml
+++ b/argocd/system/minio/templates/ingress.yml
@@ -1,0 +1,63 @@
+---
+# HTTPS Ingress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minio-console-ingress
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # HTTPS as entry point
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    # Enable TLS
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    # Enable cert-manager to create automatically the SSL certificate and store in Secret
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.certmanager.tlsIssuer }}-issuer
+    cert-manager.io/common-name: {{ .Values.ingress.console }}
+spec:
+  tls:
+    - hosts:
+        - {{ .Values.ingress.console }}
+      secretName: minio-tls
+  rules:
+    - host: {{ .Values.ingress.console }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: minio-console
+                port:
+                  number: 9001
+
+---
+# HTTPS Ingress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minio-ingress
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # HTTPS as entry point
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    # Enable TLS
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    # Enable cert-manager to create automatically the SSL certificate and store in Secret
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.certmanager.tlsIssuer }}-issuer
+    cert-manager.io/common-name: {{ .Values.ingress.host }}
+spec:
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: minio-tls
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: minio
+                port:
+                  number: 9000

--- a/argocd/system/minio/templates/ingress.yml
+++ b/argocd/system/minio/templates/ingress.yml
@@ -17,7 +17,7 @@ spec:
   tls:
     - hosts:
         - {{ .Values.ingress.console }}
-      secretName: minio-tls
+      secretName: minio-console-tls
   rules:
     - host: {{ .Values.ingress.console }}
       http:

--- a/argocd/system/minio/templates/minio-externalsecret.yaml
+++ b/argocd/system/minio/templates/minio-externalsecret.yaml
@@ -22,3 +22,15 @@ spec:
       property: key
       conversionStrategy: Default # ArgoCD sync issue
       decodingStrategy: None # ArgoCD sync issue
+  - secretKey: lokiPassword
+    remoteRef:
+      key: minio/loki
+      property: key
+      conversionStrategy: Default # ArgoCD sync issue
+      decodingStrategy: None # ArgoCD sync issue
+  - secretKey: tempoPassword
+    remoteRef:
+      key: minio/tempo
+      property: key
+      conversionStrategy: Default # ArgoCD sync issue
+      decodingStrategy: None # ArgoCD sync issue

--- a/argocd/system/minio/templates/minio-externalsecret.yaml
+++ b/argocd/system/minio/templates/minio-externalsecret.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: minio-externalsecret
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: minio-secret
+  data:
+  - secretKey: rootUser
+    remoteRef:
+      key: minio/root
+      property: user
+      conversionStrategy: Default # ArgoCD sync issue
+      decodingStrategy: None # ArgoCD sync issue
+  - secretKey: rootPassword
+    remoteRef:
+      key: minio/root
+      property: key
+      conversionStrategy: Default # ArgoCD sync issue
+      decodingStrategy: None # ArgoCD sync issue

--- a/argocd/system/minio/values.yaml
+++ b/argocd/system/minio/values.yaml
@@ -1,0 +1,32 @@
+# Ingress configuration
+ingress:
+  host: s3.picluster.ricsanfre.com
+  console: minio.picluster.ricsanfre.com
+  # configure cert-manager issuer
+  certmanager:
+    # tlsIssuer=letsecrypt to generate valid TLS certficiate using IONOS API
+    # tlsIssuer=ca to generate a CA-signed certificate (not valid)
+    tlsIssuer: letsencrypt
+
+
+###################
+# minio subchart
+###################
+
+minio:
+  # Get root user/password from secret
+  existingSecret: minio-secret
+
+  # Number of drives attached to a node
+  drivesPerNode: 1
+  # Number of MinIO containers running
+  replicas: 3
+  # Number of expanded MinIO clusters
+  pools: 1
+
+  # Persistence
+  persistence:
+    enabled: true
+    storageClass: "longhorn"
+    accessMode: ReadWriteOnce
+    size: 10Gi

--- a/argocd/system/minio/values.yaml
+++ b/argocd/system/minio/values.yaml
@@ -30,3 +30,8 @@ minio:
     storageClass: "longhorn"
     accessMode: ReadWriteOnce
     size: 10Gi
+
+  # Resource request
+  resources:
+    requests:
+      memory: 1Gi

--- a/argocd/system/minio/values.yaml
+++ b/argocd/system/minio/values.yaml
@@ -35,3 +35,48 @@ minio:
   resources:
     requests:
       memory: 1Gi
+
+  # Minio Buckets
+  buckets:
+    - name: k3s-loki
+      policy: read-write
+    - name: k3s-tempo
+      policy: read-write
+
+  # Minio Policies
+  policies:
+    - name: loki
+      statements:
+        - resources:
+            - 'arn:aws:s3:::k3s-loki'
+            - 'arn:aws:s3:::k3s-loki/*'
+          actions:
+            - "s3:DeleteObject"
+            - "s3:GetObject"
+            - "s3:ListBucket"
+            - "s3:PutObject"
+    - name: tempo
+      statements:
+        - resources:
+            - 'arn:aws:s3:::k3s-tempo'
+            - 'arn:aws:s3:::k3s-tempo/*'
+          actions:
+            - "s3:DeleteObject"
+            - "s3:GetObject"
+            - "s3:ListBucket"
+            - "s3:PutObject"
+            - "s3:GetObjectTagging"
+            - "s3:PutObjectTagging"
+
+  # Minio Users
+  users:
+    - accessKey: loki
+      existingSecret: minio-secret
+      existingSecretKey: lokiPassword
+      policy: loki
+    - accessKey: tempo
+      existingSecret: minio-secret
+      existingSecretKey: tempoPassword
+      policy: tempo
+
+

--- a/argocd/system/minio/values.yaml
+++ b/argocd/system/minio/values.yaml
@@ -39,9 +39,9 @@ minio:
   # Minio Buckets
   buckets:
     - name: k3s-loki
-      policy: read-write
+      policy: none
     - name: k3s-tempo
-      policy: read-write
+      policy: none
 
   # Minio Policies
   policies:

--- a/argocd/system/tracing/values.yaml
+++ b/argocd/system/tracing/values.yaml
@@ -25,11 +25,10 @@ tempo-distributed:
       backend: s3
       s3:
         bucket: k3s-tempo
-        endpoint: s3.picluster.ricsanfre.com:9091
-        region: eu-west-1
+        endpoint: minio.minio:9000
         access_key: ${MINIO_ACCESS_KEY_ID}
         secret_key: ${MINIO_SECRET_ACCESS_KEY}
-        insecure: false
+        insecure: true
 
   # Configure distributor
   distributor:

--- a/argocd/system/velero/values.yaml
+++ b/argocd/system/velero/values.yaml
@@ -41,7 +41,7 @@ velero:
       config:
         region: eu-west-1
         s3ForcePathStyle: true
-        s3Url: https://s3.picluster.ricsanfre.com:9091
+        s3Url: https://s3.ricsanfre.com:9091
         # insecureSkipTLSVerify: true
     # Enable CSI snapshot support
     features: EnableCSI

--- a/docs/_data/docs.yml
+++ b/docs/_data/docs.yml
@@ -17,7 +17,7 @@
   - node
 - title: External Services
   docs:
-  - minio
+  - s3-backup
   - vault
 - title: K3S Installation
   docs:
@@ -34,6 +34,7 @@
 - title: Storage
   docs:
   - longhorn
+  - minio
 - title: Monitoring
   docs:
   - observability

--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -202,7 +202,7 @@ Even whe the premise is to deploy all services in the kubernetes cluster, there 
 
 ### Self-hosted external services 
 
-There is another list of services that I have decided to run outside the kuberentes cluster but not using any public cloud service.
+There is another list of services that I have decided to run outside the kuberentes cluster selfhosting them on VMs running in Public Cloud, using [Oracle Cloud Infrastructure (OCI) free tier](https://www.oracle.com/es/cloud/free/).
 
 |  |External Service | Resource | Purpose |
 | --- | --- | --- | --- |

--- a/docs/_docs/loki.md
+++ b/docs/_docs/loki.md
@@ -44,9 +44,10 @@ Grafana Loki needs to store two different types of data: chunks and indexes. Bot
 
 {{site.data.alerts.note}}
 
-As part of the backup infrastructure a bare-metal Minio S3 server has been configured in `node1`. See documentation: [Backup & Restore - Minio S3 Object Store Server](/docs/backup/#minio-s3-object-storage-server). So I will re-use it as Loki backend.
+Loki helm chart is able to install this Minio service as a subchart, but its installation will be disabled and Minio Storage Service already deployed in the cluster will be used as Loki's backend. 
 
-As alternative a Minio server can be deployed as a another kubernetes service. Loki helm chart is able to install this Minio service as a subchart.
+As part of Minio Storage Service installation, loki's S3 bucket, policy and user is already configured.
+See documentation: [Minio S3 Object Storage Service](/docs/minio).
 
 {{site.data.alerts.end}}
 
@@ -210,11 +211,11 @@ Installation from helm chart. There are two alternatives:
 
   - Disable self-monitoring (`monitoring.selfmonitoring`) and helm-test validation (`test.enabled`)
 
-- Step 3: Install Loki in `logging` namespace
+- Step 5: Install Loki in `logging` namespace
   ```shell
   helm install loki grafana/loki -f loki-values.yml --namespace logging
   ```
-- Step 4: Check status of Loki pods
+- Step 6: Check status of Loki pods
   ```shell
   kubectl get pods -l app.kubernetes.io/name=loki -n logging
   ```

--- a/docs/_docs/minio-baremetal.md
+++ b/docs/_docs/minio-baremetal.md
@@ -1,0 +1,276 @@
+---
+title: S3 Backup Backend (Minio)
+permalink: /docs/s3-backup/
+description: How to deploy a Minio S3 object storage server in Bare-metal environment as backup backend for our Raspberry Pi Kubernetes Cluster.
+last_modified_at: "17-02-2023"
+---
+
+Minio can be deployed as a Kuberentes service or as stand-alone in bare-metal environment. Since I want to use Minio Server for backing-up/restoring the cluster itself, I will go with a bare-metal installation, considering Minio as an external service in Kubernetes.
+
+Official [documentation](https://docs.min.io/minio/baremetal/installation/deploy-minio-standalone.html) can be used for installing stand-alone Minio Server in bare-metal environment. 
+
+For a more secured and multi-user Minio installation the instructions of this [post](https://www.civo.com/learn/create-a-multi-user-minio-server-for-s3-compatible-object-hosting) can be used.
+
+For installing Minio S3 storage server, I am using a VM (Ubuntu OS) hosted in Public Cloud (Oracle Cloud Infrastructure), but any linux server/VM that is not not part of the cluster can be used.
+
+Minio installation and configuration tasks have been automated with Ansible developing a role: **ricsanfre.minio**. This role, installs Minio Server and Minio Client and automatically create S3 buckets, and configure users and ACLs for securing the access.
+
+## Minio installation (baremetal server)
+
+- Step 1. Create minio's UNIX user/group
+
+  ```shell
+  sudo groupadd minio
+  sudo useradd minio -g minio
+  ```
+- Step 2. Create minio's S3 storage directory
+
+  ```shell
+  sudo mkdir /storage/minio
+  chown -R minio:minio /storage/minio
+  chmod -R 750 /storage/minio
+  ```
+
+- Step 3. Create minio's config directories
+
+  ```shell
+  sudo mkdir -p /etc/minio
+  sudo mkdir -p /etc/minio/ssl
+  sudo mkdir -p /etc/minio/policy
+  chown -R minio:minio /etc/minio
+  chmod -R 750 /etc/minio
+  ```
+
+- Step 4. Download server binary (`minio`) and minio client (`mc`) and copy them to `/usr/local/bin`
+
+  ```shell
+   wget https://dl.min.io/server/minio/release/linux-<arch>/minio
+   wget https://dl.minio.io/client/mc/release/linux-<arch>/mc
+   chmod +x minio
+   chmod +x mc
+   sudo mv minio /usr/local/bin/minio
+   sudo mv mc /usr/local/bin/mc
+  ```
+  where `<arch>` is amd64 or arm64.
+
+- Step 5: Create minio Config file `/etc/minio/minio.conf`
+
+  This file contains environment variables that will be used by minio server.
+  ```
+  # Minio local volumes.
+  MINIO_VOLUMES="/storage/minio"
+
+  # Minio cli options.
+  MINIO_OPTS="--address :9091 --console-address :9092 --certs-dir /etc/minio/ssl"
+
+  # Access Key of the server.
+  MINIO_ROOT_USER="<admin_user>"
+  # Secret key of the server.
+  MINIO_ROOT_PASSWORD="<admin_user_passwd>"
+  # Minio server region
+  MINIO_SITE_REGION="eu-west-1"
+  # Minio server URL
+  MINIO_SERVER_URL="https://s3.picluster.ricsanfre.com:9091"
+  ```
+
+  Minio is configured with the following parameters:
+
+  - Minio Server API Port 9091 (`MINIO_OPTS`="--address :9091")
+  - Minio Console Port: 9092 (`MINIO_OPTS`="--console-address :9092")
+  - Minio Storage data dir (`MINIO_VOLUMES`): `/storage/minio`
+  - Minio Site Region (`MINIO_SITE_REGION`): `eu-west-1`
+  - SSL certificates stored in (`MINIO_OPTS`="--certs-dir /etc/minio/ssl"): `/etc/minio/ssl`.
+  - Minio server URL (`MINIO_SERVER_URL`): Url used to connecto to Minio Server API
+
+- Step 6. Create systemd minio service file `/etc/systemd/system/minio.service`
+
+  ```
+  [Unit]
+  Description=MinIO
+  Documentation=https://docs.min.io
+  Wants=network-online.target
+  After=network-online.target
+  AssertFileIsExecutable=/usr/local/bin/minio
+
+  [Service]
+  WorkingDirectory=/usr/local/
+
+  User=minio
+  Group=minio
+  ProtectProc=invisible
+
+  EnvironmentFile=/etc/minio/minio.conf
+  ExecStartPre=/bin/bash -c "if [ -z \"${MINIO_VOLUMES}\" ]; then echo \"Variable MINIO_VOLUMES not set in /etc/minio/minio.conf\"; exit 1; fi"
+
+  ExecStart=/usr/local/bin/minio server $MINIO_OPTS $MINIO_VOLUMES
+
+  # Let systemd restart this service always
+  Restart=always
+
+  # Specifies the maximum file descriptor number that can be opened by this process
+  LimitNOFILE=65536
+
+  # Specifies the maximum number of threads this process can create
+  TasksMax=infinity
+
+  # Disable timeout logic and wait until process is stopped
+  TimeoutStopSec=infinity
+  SendSIGKILL=no
+
+  [Install]
+  WantedBy=multi-user.target
+  ```
+  This service start minio server using minio UNIX group, loading environment variables located in `/etc/minio/minio.conf` and executing the following startup command:
+
+  ```shell
+  /usr/local/minio server $MINIO_OPTS $MINIO_VOLUMES
+  ```
+
+- Step 7. Enable minio systemd service
+
+  ```shell
+  sudo systemctl enable minio.service
+  ```
+
+- Step 8. Create Minio SSL certificate
+
+  In case you have your own domain, a valid SSL certificate signed by [Letsencrypt](https://letsencrypt.org/) can be obtained for Minio server, using [Certbot](https://certbot.eff.org/).
+
+  See certbot installation instructions in [CertManager - Letsencrypt Certificates Section](/docs/certmanager/#installing-certbot-ionos). Those instructions indicate how to install certbot using DNS challenge with IONOS DNS provider (my DNS provider). Similar procedures can be followed for other DNS providers.
+
+  Letsencrypt using HTTP challenge is avoided for security reasons (cluster services are not exposed to public internet).
+
+  If generating valid SSL certificate is not possible, selfsigned certificates with a custom CA can be used instead.
+
+  {{site.data.alerts.important}}
+
+  `restic` backup to a S3 Object Storage backend using self-signed certificates does not work (See issue [#26](https://github.com/ricsanfre/pi-cluster/issues/26)). However, it works if SSL certificates are signed using a custom CA.
+
+  {{site.data.alerts.end}}
+
+  Follow this procedure for creating a self-signed certificate for Minio Server
+
+  1. Create a self-signed CA key and self-signed certificate
+
+     ```shell
+     openssl req -x509 \
+            -sha256 \
+            -nodes \
+            -newkey rsa:4096 \
+            -subj "/CN=Ricsanfre CA" \
+            -keyout rootCA.key -out rootCA.crt
+     ```
+  2. Create a SSL certificate for Minio server signed using the custom CA
+    
+     ```shell
+     openssl req -new -nodes -newkey rsa:4096 \
+                 -keyout minio.key \
+                 -out minio.csr \
+                 -batch \
+                 -subj "/C=ES/ST=Madrid/L=Madrid/O=Ricsanfre CA/OU=picluster/CN=s3.picluster.ricsanfre.com"
+
+      openssl x509 -req -days 365000 -set_serial 01 \
+            -extfile <(printf "subjectAltName=DNS:s3.picluster.ricsanfre.com") \
+            -in minio.csr \
+            -out minio.crt \
+            -CA rootCA.crt \
+            -CAkey rootCA.key
+     ```
+
+  Once the certificate is created, public certificate and private key need to be installed in Minio server following this procedure:
+
+
+  1. Copy public certificate `minio.crt` as `/etc/minio/ssl/public.crt`
+
+     ```shell
+     sudo cp minio.crt /etc/minio/ssl/public.crt
+     sudo chown minio:minio /etc/minio/ssl/public.crt
+     ```
+  2. Copy private key `minio.key` as `/etc/minio/ssl/private.key`
+
+     ```shell
+     cp minio.key /etc/minio/ssl/private.key
+     sudo chown minio:minio /etc/minio/ssl/private.key
+     ```
+  3. Restart minio server.
+     
+     ```shell
+     sudo systemctl restart minio.service
+     ```
+
+  {{site.data.alerts.note}}
+
+  Certificate must be created for the DNS name associated to MINIO S3 service, i.e `s3.picluster.ricsanfre.com`.
+
+  `MINIO_SERVER_URL` environment variable need to be configured, to avoid issues with TLS certificates without IP Subject Alternative Names.
+
+  {{site.data.alerts.end}}
+
+  To connect to Minio console use the URL https://s3.picluster.ricsanfre.com:9091
+
+- Step 9. Configure minio client: `mc`
+
+  Configure connection alias to minio server.
+  
+  ```shell
+  mc alias set minio_alias <minio_url> <minio_root_user> <minio_root_password>
+  ```
+
+## Minio Configuration
+
+### Buckets
+
+The following buckets need to be created for backing-up different cluster components:
+
+- Longhorn Backup: `k3s-longhorn`
+- Velero Backup: `k3s-velero`
+- OS backup: `restic`
+
+Buckets can be created using Minio's CLI (`mc`)
+
+```shell
+mc mb <minio_alias>/<bucket_name> 
+```
+Where: `<minio_alias>` is the mc's alias connection to Minio Server using admin user credentials, created during Minio installation in step 9.
+
+### Users and ACLs
+
+Following users will be created to grant access to Minio S3 buckets:
+
+- `longhorn` with read-write access to `k3s-longhorn` bucket.
+- `velero` with read-write access to `k3s-velero` bucket. 
+- `restic` with read-write access to `restic` bucket
+
+  
+Users can be created usinng Minio's CLI
+```shell
+mc admin user add <minio_alias> <user_name> <user_password>
+```
+Access policies to the different buckets can be assigned to the different users using the command:
+
+```shell
+mc admin policy add <minio_alias> <user_name> user_policy.json
+```
+Where `user_policy.json`, contains AWS access policies definition like:
+
+```json
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+      "Effect": "Allow",
+      "Action": [
+          "s3:DeleteObject",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:PutObject"
+      ],
+      "Resource": [
+          "arn:aws:s3:::bucket_name",
+          "arn:aws:s3:::bucket_name/*"
+      ]
+  }  
+]
+}
+``` 
+This policy grants read-write access to `bucket_name`. For each user a different json need to be created, granting access to dedicated bucket. Those json files can be stored in `/etc/minio/policy` directory.

--- a/docs/_docs/tracing.md
+++ b/docs/_docs/tracing.md
@@ -53,9 +53,10 @@ Grafana Tempo needs to store two different types of data: chunks and indexes. Bo
 
 {{site.data.alerts.note}}
 
-As part of the backup infrastructure a bare-metal Minio S3 server has been configured in `node1`. See documentation: [Backup & Restore - Minio S3 Object Store Server](/docs/backup/#minio-s3-object-storage-server). So I will re-use it as Tempo backend.
+Tempo helm chart is able to install this Minio service as a subchart, but its installation will be disabled and Minio Storage Service already deployed in the cluster will be used as Tempo's backend. 
 
-As alternative a Minio server can be deployed as a another kubernetes service. Tempo distribubted helm chart is able to install this Minio service as a subchart.
+As part of Minio Storage Service installation, Tempo's S3 bucket, policy and user is already configured.
+See documentation: [Minio S3 Object Storage Service](/docs/minio).
 
 {{site.data.alerts.end}}
 


### PR DESCRIPTION

This PR includes:

- Deployment of Minio cluster service to be used by Loki/Tempo/Mimir, etc
- Use external Minio server only for backups (Velero, Restic and Longhorn)
- Migrate externals services (Minio and Vault) outside the cluster, using public cloud VMs


Fix #95