### PR TITLE
Using vault secret for elastic user

### DIFF
--- a/ansible/vars/vault.yml
+++ b/ansible/vars/vault.yml
@@ -37,7 +37,7 @@ vault:
   # elastic search
   elasticsearch:
     elastic:
-      user: elastic
+      user: admin
       password: s1cret0
   # Fluentd
   fluentd:

--- a/ansible/vars/vault.yml.j2
+++ b/ansible/vars/vault.yml.j2
@@ -38,7 +38,7 @@ vault:
   # elasticsearch and fluentd
   logging:
     elastic:
-      user: elastic
+      user: admin
       password: {{ elasticsearch_admin_password }}
     fluentd:
       shared_key: {{ fluentd_shared_key }}

--- a/argocd/system/logging/templates/elasticsearch-admin-externalsecret.yaml
+++ b/argocd/system/logging/templates/elasticsearch-admin-externalsecret.yaml
@@ -1,0 +1,32 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: elasticsearch-admin-externalsecret
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: es-admin-user-file-realm
+    template:
+      type: kubernetes.io/basic-auth
+      data:
+        username: |-
+          {{ `{{ .username | toString }}` }}
+        password: |-
+          {{ `{{ .password | toString }}` }}
+        roles: superuser
+  data:
+  - secretKey: username
+    remoteRef:
+      key: logging/elastic
+      property: user
+      conversionStrategy: Default # ArgoCD sync issue
+      decodingStrategy: None # ArgoCD sync issue
+  - secretKey: password
+    remoteRef:
+      key: logging/elastic
+      property: password
+      conversionStrategy: Default # ArgoCD sync issue
+      decodingStrategy: None # ArgoCD sync issue

--- a/argocd/system/logging/templates/elasticsearch-fluentd-role.yaml
+++ b/argocd/system/logging/templates/elasticsearch-fluentd-role.yaml
@@ -1,0 +1,19 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: es-fluentd-roles-secret
+stringData:
+  roles.yml: |-
+    fluentd_role:
+      cluster: ['manage_index_templates', 'monitor', 'manage_ilm']
+      indices:
+      - names: [ '*' ]
+        privileges: [
+          'indices:admin/create',
+          'write',
+          'create',
+          'delete',
+          'create_index',
+          'manage',
+          'manage_ilm'
+        ]

--- a/argocd/system/logging/templates/elasticsearch-fluentd-secret.yaml
+++ b/argocd/system/logging/templates/elasticsearch-fluentd-secret.yaml
@@ -1,0 +1,10 @@
+{{- $passwordValue := (randAlphaNum 16) | b64enc | quote }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: es-fluentd-user-file-realm
+type: kubernetes.io/basic-auth
+data:
+  username: {{ "fluentd" | b64enc }}
+  password: {{ $passwordValue }}
+  roles: {{ "fluentd_role" | b64enc }}

--- a/argocd/system/logging/templates/elasticsearch-prometheus-role.yaml
+++ b/argocd/system/logging/templates/elasticsearch-prometheus-role.yaml
@@ -1,0 +1,17 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: es-prometheus-roles-secret
+stringData:
+  roles.yml: |-
+    prometheus_role:
+      cluster: [
+        'cluster:monitor/health',
+        'cluster:monitor/nodes/stats',
+        'cluster:monitor/state',
+        'cluster:monitor/nodes/info',
+        'cluster:monitor/prometheus/metrics'
+      ] 
+      indices:
+      - names: [ '*' ]
+        privileges: [ 'indices:admin/aliases/get', 'indices:admin/mappings/get', 'indices:monitor/stats', 'indices:data/read/search' ]

--- a/argocd/system/logging/templates/elasticsearch-prometheus-secret.yaml
+++ b/argocd/system/logging/templates/elasticsearch-prometheus-secret.yaml
@@ -1,0 +1,10 @@
+{{- $passwordValue := (randAlphaNum 16) | b64enc | quote }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: es-prometheus-user-file-realm
+type: kubernetes.io/basic-auth
+data:
+  username: {{ "prometheus" | b64enc }}
+  password: {{ $passwordValue }}
+  roles: {{ "prometheus_role" | b64enc }}

--- a/argocd/system/logging/templates/elasticsearch.yaml
+++ b/argocd/system/logging/templates/elasticsearch.yaml
@@ -10,8 +10,14 @@ spec:
       selfSignedCertificate:
         disabled: true
   auth:
+    roles:
+    - secretName: es-fluentd-roles-secret
+    - secretName: es-prometheus-roles-secret
+    - secretName: my-roles-secret
     fileRealm:
     - secretName: es-admin-user-file-realm
+    - secretName: es-fluentd-user-file-realm
+    - secretName: es-prometheus-user-file-realm
   nodeSets:
     - name: default
       count: {{ .Values.elasticsearch.clusterNodes }}

--- a/argocd/system/logging/templates/elasticsearch.yaml
+++ b/argocd/system/logging/templates/elasticsearch.yaml
@@ -13,7 +13,6 @@ spec:
     roles:
     - secretName: es-fluentd-roles-secret
     - secretName: es-prometheus-roles-secret
-    - secretName: my-roles-secret
     fileRealm:
     - secretName: es-admin-user-file-realm
     - secretName: es-fluentd-user-file-realm

--- a/argocd/system/logging/templates/elasticsearch.yaml
+++ b/argocd/system/logging/templates/elasticsearch.yaml
@@ -9,6 +9,9 @@ spec:
     tls:
       selfSignedCertificate:
         disabled: true
+  auth:
+    fileRealm:
+    - secretName: es-admin-user-file-realm
   nodeSets:
     - name: default
       count: {{ .Values.elasticsearch.clusterNodes }}

--- a/argocd/system/logging/values.yaml
+++ b/argocd/system/logging/values.yaml
@@ -213,13 +213,16 @@ fluentd:
       value: "9200"
     # Elasticsearch user
     - name: FLUENT_ELASTICSEARCH_USER
-      value: "elastic"
+      valueFrom:
+        secretKeyRef:
+          name: "es-admin-user-file-realm"
+          key: username
     # Elastic operator stores elastic user password in a secret
     - name: FLUENT_ELASTICSEARCH_PASSWORD
       valueFrom:
         secretKeyRef:
-          name: "efk-es-elastic-user"
-          key: elastic
+          name: "es-admin-user-file-realm"
+          key: password
     # Fluentd forward security
     - name: FLUENTD_FORWARD_SEC_SHARED_KEY
       valueFrom:
@@ -697,15 +700,14 @@ fluent-bit:
 #########################
 
 prometheus-elasticsearch-exporter:
-  # Elastic search user
-  env:
-    ES_USERNAME: elastic
-
   # Elastic search passord from secret
   extraEnvSecrets:
+    ES_USERNAME:
+      secret: es-admin-user-file-realm
+      key: username
     ES_PASSWORD:
-      secret: efk-es-elastic-user
-      key: elastic
+      secret: es-admin-user-file-realm
+      key: password
 
   # Elastic search URI
   es:

--- a/argocd/system/logging/values.yaml
+++ b/argocd/system/logging/values.yaml
@@ -215,13 +215,13 @@ fluentd:
     - name: FLUENT_ELASTICSEARCH_USER
       valueFrom:
         secretKeyRef:
-          name: "es-admin-user-file-realm"
+          name: "es-fluentd-user-file-realm"
           key: username
     # Elastic operator stores elastic user password in a secret
     - name: FLUENT_ELASTICSEARCH_PASSWORD
       valueFrom:
         secretKeyRef:
-          name: "es-admin-user-file-realm"
+          name: "es-fluentd-user-file-realm"
           key: password
     # Fluentd forward security
     - name: FLUENTD_FORWARD_SEC_SHARED_KEY
@@ -703,10 +703,10 @@ prometheus-elasticsearch-exporter:
   # Elastic search passord from secret
   extraEnvSecrets:
     ES_USERNAME:
-      secret: es-admin-user-file-realm
+      secret: es-prometheus-user-file-realm
       key: username
     ES_PASSWORD:
-      secret: es-admin-user-file-realm
+      secret: es-prometheus-user-file-realm
       key: password
 
   # Elastic search URI

--- a/docs/_docs/logging-forwarder-aggregator.md
+++ b/docs/_docs/logging-forwarder-aggregator.md
@@ -432,13 +432,16 @@ The above Kubernetes resources, except TLS certificate and shared secret, are cr
       value: "9200"
     # Elasticsearch user
     - name: FLUENT_ELASTICSEARCH_USER
-      value: "elastic"
+      valueFrom:
+        secretKeyRef:
+          name: "es-fluentd-user-file-realm"
+          key: username
     # Elastic operator stores elastic user password in a secret
     - name: FLUENT_ELASTICSEARCH_PASSWORD
       valueFrom:
         secretKeyRef:
-          name: "efk-es-elastic-user"
-          key: elastic
+          name: "es-fluentd-user-file-realm"
+          key: password
     - name: FLUENTD_FORWARD_SEC_SHARED_KEY
       valueFrom:
         secretKeyRef:


### PR DESCRIPTION
Hi,

I noticed in the vault secrets generation a elastic user was generated but the vault secrets is not used for elasticsearch. I created the externalsecret with that reads from the vault secret and modified some of the env reference to allow that to be used.