### PR TITLE
Upgrade to longhorn 1.5.1

### DIFF
--- a/argocd/system/csi-external-snapshotter/kustomization.yaml
+++ b/argocd/system/csi-external-snapshotter/kustomization.yaml
@@ -3,8 +3,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kube-system
 resources:
-# Longhorn 1.4 is compatible with CSI Snapshot Controller 5.0.1
+# Longhorn 1.5.1 is compatible with CSI Snapshot Controller 6.2.1
 # (https://github.com/kubernetes-csi/external-snapshotter)
 # In this version of CSI Snapshot Controller kustomization files are available
-- https://github.com/kubernetes-csi/external-snapshotter/client/config/crd/?ref=v5.0.1
-- https://github.com/kubernetes-csi/external-snapshotter/deploy/kubernetes/snapshot-controller/?ref=v5.0.1
+- https://github.com/kubernetes-csi/external-snapshotter/client/config/crd/?ref=v6.2.1
+- https://github.com/kubernetes-csi/external-snapshotter/deploy/kubernetes/snapshot-controller/?ref=v6.2.1

--- a/argocd/system/longhorn-system/Chart.yaml
+++ b/argocd/system/longhorn-system/Chart.yaml
@@ -3,5 +3,5 @@ name: longhorn
 version: 0.0.0
 dependencies:
   - name: longhorn
-    version: 1.4.2
+    version: 1.5.1
     repository: https://charts.longhorn.io


### PR DESCRIPTION
Upgrading Longhorn to 1.5.1 and CSI external snaphooter to 6.2.1