### PR TITLE
Keycloak reconfiguration: setting postgreSQL passwords from external secrets

### DIFF
--- a/ansible/create_vault_credentials.yml
+++ b/ansible/create_vault_credentials.yml
@@ -55,11 +55,12 @@
         - elasticsearch_prometheus_password
         - keycloak_admin_password
         - keycloak_pi_password
+        - keycloak_postgresql_password
         - oauth2_proxy_client_secret
         - oauth2_proxy_cookie
         - oauth2_proxy_redis_password
         - grafana_client_secret
-        - kibana_client_secret
+        - postgresql_admin_password
 
     - name: Generate vault file
       ansible.builtin.template:

--- a/ansible/vars/vault.yml.j2
+++ b/ansible/vars/vault.yml.j2
@@ -23,6 +23,9 @@ vault:
     picluster-admin:
       user: piadmin
       password: {{ keycloak_pi_password }}
+    postgresql:
+      user: keycloak
+      password: {{ keycloak_postgresql_password }}
   # Oauth2-Proxy
   oauth2-proxy:
     oauth2:
@@ -73,13 +76,13 @@ vault:
     oauth2:
       client-id: grafana
       client-secret: {{ grafana_client_secret }}
-  # Kibana
-  kibana:
-    oauth2:
-      client-id: kibana
-      client-secret: {{ kibana_client_secret }}
   # Certmanager
   certmanager:
     ionos:
       public_prefix: {{ ionos_public_prefix }}
       secret: {{ ionos_secret }}
+  # PostgreSQL
+  postgresql:
+    admin:
+      user: admin
+      password: {{ postgresql_admin_password }}

--- a/argocd/bootstrap/root/values.yaml
+++ b/argocd/bootstrap/root/values.yaml
@@ -1,6 +1,6 @@
 gitops:
   repo: https://github.com/ricsanfre/pi-cluster
-  revision: patch-keycloak
+  revision: master
 
 # List of application corresponding to different sync waves
 apps:

--- a/argocd/bootstrap/root/values.yaml
+++ b/argocd/bootstrap/root/values.yaml
@@ -1,6 +1,6 @@
 gitops:
   repo: https://github.com/ricsanfre/pi-cluster
-  revision: master
+  revision: patch-keycloak
 
 # List of application corresponding to different sync waves
 apps:

--- a/argocd/system/keycloak/templates/keycloak-externalsecret.yaml
+++ b/argocd/system/keycloak/templates/keycloak-externalsecret.yaml
@@ -16,3 +16,15 @@ spec:
         property: password
         conversionStrategy: Default # ArgoCD sync issue
         decodingStrategy: None # ArgoCD sync issue
+    - secretKey: postgresql-admin-password
+      remoteRef:
+        key: postgresql/admin
+        property: password
+        conversionStrategy: Default # ArgoCD sync issue
+        decodingStrategy: None # ArgoCD sync issue
+    - secretKey: postgresql-keycloak-password
+      remoteRef:
+        key: keycloak/postgresql
+        property: password
+        conversionStrategy: Default # ArgoCD sync issue
+        decodingStrategy: None # ArgoCD sync issue

--- a/argocd/system/keycloak/templates/keycloak-externalsecret.yaml
+++ b/argocd/system/keycloak/templates/keycloak-externalsecret.yaml
@@ -22,7 +22,7 @@ spec:
         property: password
         conversionStrategy: Default # ArgoCD sync issue
         decodingStrategy: None # ArgoCD sync issue
-    - secretKey: postgresql-keycloak-password
+    - secretKey: password
       remoteRef:
         key: keycloak/postgresql
         property: password

--- a/argocd/system/keycloak/values.yaml
+++ b/argocd/system/keycloak/values.yaml
@@ -18,6 +18,18 @@ keycloak:
     existingSecret: keycloak-secret
     adminUser: admin
 
+  # postgresSQL
+  postgresql:
+    enabled: true
+    auth:
+      username: keycloak
+      database: keycloak
+      existingSecret: keycloak-secret
+      secretKeys:
+        adminPasswordKey: postgresql-admin-password
+        userPasswordKey: postgresql-keycloak-password
+    architecture: standalone
+
   # Adding additional secrets for realm configuration as environment variables
   extraEnvVarsSecret: keycloak-env-secret
 

--- a/argocd/system/keycloak/values.yaml
+++ b/argocd/system/keycloak/values.yaml
@@ -27,7 +27,7 @@ keycloak:
       existingSecret: keycloak-secret
       secretKeys:
         adminPasswordKey: postgresql-admin-password
-        userPasswordKey: postgresql-keycloak-password
+        userPasswordKey: password
     architecture: standalone
 
   # Adding additional secrets for realm configuration as environment variables


### PR DESCRIPTION
Update keycloak deployment, to use postgreSQL credentials stored in external secrets instead of letting helm chart create random passwords.