### PR TITLE
Patch

### DIFF
--- a/ansible-runner/build/requirements.yml
+++ b/ansible-runner/build/requirements.yml
@@ -26,12 +26,12 @@ roles:
     version: v1.0.4
 collections:
   - name: community.general
-    version: 8.3.0
+    version: 8.5.0
   - name: kubernetes.core
-    version: 3.0.0
+    version: 3.0.1
   - name: community.hashi_vault
-    version: 6.1.0
+    version: 6.2.0
   - name: ansible.posix
     version: 1.5.4
   - name: community.crypto
-    version: 2.17.1
+    version: 2.18.0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -26,12 +26,12 @@ roles:
     version: v1.0.4
 collections:
   - name: community.general
-    version: 8.3.0
+    version: 8.5.0
   - name: kubernetes.core
-    version: 3.0.0
+    version: 3.0.1
   - name: community.hashi_vault
-    version: 6.1.0
+    version: 6.2.0
   - name: ansible.posix
     version: 1.5.4
   - name: community.crypto
-    version: 2.17.1
+    version: 2.18.0

--- a/ansible/vars/picluster.yml
+++ b/ansible/vars/picluster.yml
@@ -233,7 +233,7 @@ restic_environment:
 #######################
 
 vault_hostname: "vault.picluster.ricsanfre.com"
-vault_version: 1.15.6
+vault_version: 1.16.1
 
 vault_dns: "{{ vault_hostname }}"
 vault_enable_tls: true

--- a/ansible/vars/picluster.yml
+++ b/ansible/vars/picluster.yml
@@ -31,7 +31,7 @@ k3s_kubelet_config: |
 # --disable 'servicelb'
 # --disable 'traefik'
 # --disable 'local-storage'
-# --node-taint 'node-role.kubernetes.io/master=true:NoSchedule'
+# --node-taint 'node-role.kubernetes.io/control-plane:NoSchedule'
 # --kube-controller-manager-arg 'bind-address=0.0.0.0'
 # --kube-proxy-arg 'metrics-bind-address=0.0.0.0'
 # --kube-scheduler-arg 'bind-address=0.0.0.0'
@@ -47,7 +47,7 @@ k3s_server_config:
     - traefik
   write-kubeconfig-mode: 644
   node-taint:
-    - 'node-role.kubernetes.io/master=true:NoSchedule'
+    - 'node-role.kubernetes.io/control-plane:NoSchedule'
   etcd-expose-metrics: true
   kubelet-arg:
     - 'config=/etc/rancher/k3s/kubelet.config'

--- a/argocd/system/logging/values.yaml
+++ b/argocd/system/logging/values.yaml
@@ -682,7 +682,7 @@ fluent-bit:
 
   # Enable fluentbit instalaltion on master node.
   tolerations:
-    - key: node-role.kubernetes.io/master
+    - key: node-role.kubernetes.io/control-plane
       operator: Exists
       effect: NoSchedule
 

--- a/docs/_docs/logging-forwarder-aggregator.md
+++ b/docs/_docs/logging-forwarder-aggregator.md
@@ -3,7 +3,7 @@ title: Log collection and distribution (Fluentbit/Fluentd)
 permalink: /docs/logging-forwarder-aggregator/
 description: How to deploy logging collection, aggregation and distribution in our Raspberry Pi Kuberentes cluster. Deploy a forwarder/aggregator architecture using Fluentbit and Fluentd. Logs are routed to Elasticsearch and Loki, so log analysis can be done using Kibana and Grafana.
 
-last_modified_at: "29-03-2024"
+last_modified_at: "05-04-2024"
 
 ---
 
@@ -1494,7 +1494,7 @@ For speed-up the installation there is available a [helm chart](https://github.c
 
   # Enable fluentbit instalaltion on master node.
   tolerations:
-    - key: node-role.kubernetes.io/master
+    - key: node-role.kubernetes.io/control-plane
       operator: Exists
       effect: NoSchedule
 
@@ -1855,7 +1855,7 @@ Fluentbit pod tolerations can be configured through helm chart value `toleration
 
 ```yml
   tolerations:
-    - key: node-role.kubernetes.io/master
+    - key: node-role.kubernetes.io/control-plane
       operator: Exists
       effect: NoSchedule
 ```


### PR DESCRIPTION
Patch contains the following updates

1) Upgrade Ansible-runner dependencies: 
   - community.hashi_vault to v6.2.0
   - kubernetes.core to v3.0.1
   - community.general to v8.5.0
   - community.crypto to v2.18.0
2) Upgrade Hashicorp Vault to 1.16.1

3) Replacing deprecated node taint to avoid scheduling pods on master nodes
    node-role.kubernetes.io/master=true:NoSchedule [is deprecated](https://kubernetes.io/docs/reference/labels-annotations-taints/#node-role-kubernetes-io-master-taint)
    node-role.kubernetes.io/control-plane:NoSchedule is the recommended way to taint a master node. (https://kubernetes.io/docs/reference/labels-annotations-taints/#node-role-kubernetes-io-control-plane-taint)

   