### PR TITLE
Cloud native databases operators (cloudnative-pg and mongodb-operator) and configuring Keycloak DB in HA with backup

### DIFF
--- a/ansible-runner/build/requirements.yml
+++ b/ansible-runner/build/requirements.yml
@@ -19,7 +19,7 @@ roles:
   - name: ricsanfre.fluentbit
     version: v1.0.4
   - name: ricsanfre.minio
-    version: v1.1.6
+    version: v1.1.8
   - name: ricsanfre.backup
     version: v1.1.3
   - name: ricsanfre.vault

--- a/ansible/create_vault_credentials.yml
+++ b/ansible/create_vault_credentials.yml
@@ -47,6 +47,7 @@
         - minio_velero_password
         - minio_loki_password
         - minio_tempo_password
+        - minio_barman_password
         - traefik_basic_auth_password
         - fluentd_shared_key
         - grafana_admin_password

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -19,7 +19,7 @@ roles:
   - name: ricsanfre.fluentbit
     version: v1.0.4
   - name: ricsanfre.minio
-    version: v1.1.6
+    version: v1.1.8
   - name: ricsanfre.backup
     version: v1.1.3
   - name: ricsanfre.vault

--- a/ansible/vars/picluster.yml
+++ b/ansible/vars/picluster.yml
@@ -153,6 +153,8 @@ minio_buckets:
     policy: read-write
   - name: k3s-tempo
     policy: read-write
+  - name: k3s-barman
+    policy: read-write
 
 # Minio users and ACLs
 minio_users:
@@ -219,6 +221,13 @@ minio_users:
                   "arn:aws:s3:::k3s-tempo/*",
                   "arn:aws:s3:::k3s-tempo"
               ]
+
+  - name: "{{ vault.minio.barman.user }}"
+    password: "{{ vault.minio.barman.key }}"
+    buckets_acl:
+      - name: k3s-barman
+        policy: read-write
+
 
 ########################
 # Restic configuration #

--- a/ansible/vars/vault.yml.j2
+++ b/ansible/vars/vault.yml.j2
@@ -55,6 +55,9 @@ vault:
     tempo:
       user: tempo
       key: {{ minio_tempo_password }}
+    barman:
+      user: barman
+      key: {{ minio_barman_password }}
   # elasticsearch and fluentd
   logging:
     es-admin:

--- a/kubernetes/bootstrap/infra/base/apps/databases-app.yaml
+++ b/kubernetes/bootstrap/infra/base/apps/databases-app.yaml
@@ -1,17 +1,17 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: oauth2-proxy
+  name: databases
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: '85'
+    argocd.argoproj.io/sync-wave: '75'
 spec:
   destination:
-    namespace: oauth2-proxy
+    namespace: databases
     name: in-cluster
   project: picluster
   source:
-    path: kubernetes/infrastructure/oauth2-proxy/overlays/prod
+    path: kubernetes/infrastructure/databases/overlays/prod
     repoURL: https://github.com/ricsanfre/pi-cluster
     targetRevision: master
   syncPolicy:

--- a/kubernetes/bootstrap/infra/base/apps/keycloak-app.yaml
+++ b/kubernetes/bootstrap/infra/base/apps/keycloak-app.yaml
@@ -4,7 +4,7 @@ metadata:
   name: keycloak
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: '70'
+    argocd.argoproj.io/sync-wave: '80'
 spec:
   destination:
     namespace: keycloak

--- a/kubernetes/bootstrap/infra/base/kustomization.yaml
+++ b/kubernetes/bootstrap/infra/base/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - apps/longhorn-app.yaml
 - apps/minio-app.yaml
 - apps/velero-app.yaml
+- apps/databases-app.yaml
 - apps/keycloak-app.yaml
 - apps/oauth2-proxy-app.yaml
 - apps/elastic-app.yaml

--- a/kubernetes/bootstrap/infra/overlays/dev/apps/databases-app.yaml
+++ b/kubernetes/bootstrap/infra/overlays/dev/apps/databases-app.yaml
@@ -1,0 +1,9 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: databases
+  namespace: argocd
+spec:
+  source:
+    path: kubernetes/infrastructure/databases/overlays/dev
+    targetRevision: master

--- a/kubernetes/bootstrap/infra/overlays/dev/kustomization.yaml
+++ b/kubernetes/bootstrap/infra/overlays/dev/kustomization.yaml
@@ -17,6 +17,7 @@ patches:
 - path: apps/longhorn-app.yaml
 - path: apps/minio-app.yaml
 - path: apps/velero-app.yaml
+- path: apps/databases-app.yaml
 - path: apps/keycloak-app.yaml
 - path: apps/oauth2-proxy-app.yaml
 - path: apps/elastic-app.yaml

--- a/kubernetes/infrastructure/databases/base/cloudnative-pg-values.yaml
+++ b/kubernetes/infrastructure/databases/base/cloudnative-pg-values.yaml
@@ -1,0 +1,9 @@
+# cloudnative-pg helm values (base)
+
+crds:
+  create: true
+
+monitoring:
+  podMonitorEnabled: false
+  grafanaDashboard:
+    create: true

--- a/kubernetes/infrastructure/databases/base/kustomization.yaml
+++ b/kubernetes/infrastructure/databases/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: databases
+
+resources:
+  - ns.yaml

--- a/kubernetes/infrastructure/databases/base/mongodb-database-example.yaml
+++ b/kubernetes/infrastructure/databases/base/mongodb-database-example.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: mongodbcommunity.mongodb.com/v1
+kind: MongoDBCommunity
+metadata:
+  name: example-mongodb
+  namespace: mongodb
+spec:
+  members: 1
+  type: ReplicaSet
+  version: "6.0.5"
+  security:
+    authentication:
+      modes: ["SCRAM"]
+  users:
+    - name: my-user
+      db: admin
+      passwordSecretRef: # a reference to the secret that will be used to generate the user's password
+        name: my-user-password
+      roles:
+        - name: clusterAdmin
+          db: admin
+        - name: userAdminAnyDatabase
+          db: admin
+      scramCredentialsSecretName: my-scram
+  additionalMongodConfig:
+    storage.wiredTiger.engineConfig.journalCompressor: zlib
+
+# the user credentials will be generated from this secret
+# once the credentials are generated, this secret is no longer required
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-user-password
+  namespace: mongodb
+type: Opaque
+stringData:
+  password: s1cret0

--- a/kubernetes/infrastructure/databases/base/mongodb-operator-values.yaml
+++ b/kubernetes/infrastructure/databases/base/mongodb-operator-values.yaml
@@ -1,0 +1,3 @@
+# mongodb-operator helm values (base)
+
+

--- a/kubernetes/infrastructure/databases/base/ns.yaml
+++ b/kubernetes/infrastructure/databases/base/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: databases

--- a/kubernetes/infrastructure/databases/overlays/dev/cloudnative-pg-values.yaml
+++ b/kubernetes/infrastructure/databases/overlays/dev/cloudnative-pg-values.yaml
@@ -1,0 +1,1 @@
+# cloudnative-pg helm values (dev patch)

--- a/kubernetes/infrastructure/databases/overlays/dev/kustomization.yaml
+++ b/kubernetes/infrastructure/databases/overlays/dev/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: databases
+
+resources:
+  - ../../base
+
+helmCharts:
+  - name: community-operator
+    repo: https://mongodb.github.io/helm-charts
+    version: 0.10.0
+    releaseName: "mongodb-community-operator"
+    namespace: databases
+    valuesFile: ../../base/mongodb-operator-values.yaml
+    includeCRDs: true
+    additionalValuesFiles:
+      - mongodb-operator-values.yaml
+  - name: cloudnative-pg
+    repo: https://cloudnative-pg.github.io/charts
+    version: 0.21.5
+    releaseName: "cloudnative-pg"
+    namespace: databases
+    valuesFile: ../../base/cloudnative-pg-values.yaml
+    includeCRDs: true
+    additionalValuesFiles:
+      - cloudnative-pg-values.yaml    

--- a/kubernetes/infrastructure/databases/overlays/dev/mongodb-operator-values.yaml
+++ b/kubernetes/infrastructure/databases/overlays/dev/mongodb-operator-values.yaml
@@ -1,0 +1,1 @@
+# mongodb-operator helm values (dev patch)

--- a/kubernetes/infrastructure/databases/overlays/prod/cloudnative-pg-values.yaml
+++ b/kubernetes/infrastructure/databases/overlays/prod/cloudnative-pg-values.yaml
@@ -1,0 +1,1 @@
+# cloudnative-pg helm values (prod patch)

--- a/kubernetes/infrastructure/databases/overlays/prod/kustomization.yaml
+++ b/kubernetes/infrastructure/databases/overlays/prod/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: databases
+
+resources:
+  - ../../base
+
+helmCharts:
+  - name: community-operator
+    repo: https://mongodb.github.io/helm-charts
+    version: 0.10.0
+    releaseName: "mongodb-community-operator"
+    namespace: databases
+    valuesFile: ../../base/mongodb-operator-values.yaml
+    includeCRDs: true
+    additionalValuesFiles:
+      - mongodb-operator-values.yaml
+  - name: cloudnative-pg
+    repo: https://cloudnative-pg.github.io/charts
+    version: 0.21.5
+    releaseName: "cloudnative-pg"
+    namespace: databases
+    valuesFile: ../../base/cloudnative-pg-values.yaml
+    includeCRDs: true
+    additionalValuesFiles:
+      - cloudnative-pg-values.yaml

--- a/kubernetes/infrastructure/databases/overlays/prod/mongodb-operator-values.yaml
+++ b/kubernetes/infrastructure/databases/overlays/prod/mongodb-operator-values.yaml
@@ -1,0 +1,1 @@
+# mongodb-operator helm values (prod patch)

--- a/kubernetes/infrastructure/keycloak/base/keycloak-db-externalsecret.yaml
+++ b/kubernetes/infrastructure/keycloak/base/keycloak-db-externalsecret.yaml
@@ -1,0 +1,37 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: keycloak-db-externalsecret
+  namespace: keycloak
+spec:
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: keycloak-db-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        username: "keycloak"
+        password: "{{ .password | toString }}"
+        superuserpassword: "{{ .postgresql-admin-password | toString }}"
+
+  data:
+    - secretKey: postgresql-admin-password
+      remoteRef:
+        key: postgresql/admin
+        property: password
+        conversionStrategy: Default # ArgoCD sync issue
+        decodingStrategy: None # ArgoCD sync issue
+        metadataPolicy: None # ArgoCD sync issue
+    - secretKey: password
+      remoteRef:
+        key: keycloak/postgresql
+        property: password
+        conversionStrategy: Default # ArgoCD sync issue
+        decodingStrategy: None # ArgoCD sync issue
+        metadataPolicy: None # ArgoCD sync issue

--- a/kubernetes/infrastructure/keycloak/base/keycloak-db.yaml
+++ b/kubernetes/infrastructure/keycloak/base/keycloak-db.yaml
@@ -16,4 +16,20 @@ spec:
       owner: keycloak
       secret:
         name: keycloak-db-secret
-
+  backup:
+    barmanObjectStore:
+      data:
+        compression: bzip2
+      wal:
+        compression: bzip2
+        maxParallel: 8
+      destinationPath: s3://k3s-barman/keycloak-db
+      endpointURL: https://s3.ricsanfre.com:9091
+      s3Credentials:
+        accessKeyId:
+          name: keycloak-minio-secret
+          key: AWS_ACCESS_KEY_ID
+        secretAccessKey:
+          name: keycloak-minio-secret
+          key: AWS_SECRET_ACCESS_KEY
+    retentionPolicy: "30d"

--- a/kubernetes/infrastructure/keycloak/base/keycloak-db.yaml
+++ b/kubernetes/infrastructure/keycloak/base/keycloak-db.yaml
@@ -1,0 +1,19 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: keycloak-db
+spec:
+  instances: 3
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.3-4
+  storage:
+    size: 10Gi
+    storageClass: longhorn
+  monitoring:
+    enablePodMonitor: true
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      secret:
+        name: keycloak-db-secret
+

--- a/kubernetes/infrastructure/keycloak/base/keycloak-externalsecret.yaml
+++ b/kubernetes/infrastructure/keycloak/base/keycloak-externalsecret.yaml
@@ -17,17 +17,3 @@ spec:
         conversionStrategy: Default # ArgoCD sync issue
         decodingStrategy: None # ArgoCD sync issue
         metadataPolicy: None # ArgoCD sync issue
-    - secretKey: postgresql-admin-password
-      remoteRef:
-        key: postgresql/admin
-        property: password
-        conversionStrategy: Default # ArgoCD sync issue
-        decodingStrategy: None # ArgoCD sync issue
-        metadataPolicy: None # ArgoCD sync issue
-    - secretKey: password
-      remoteRef:
-        key: keycloak/postgresql
-        property: password
-        conversionStrategy: Default # ArgoCD sync issue
-        decodingStrategy: None # ArgoCD sync issue
-        metadataPolicy: None # ArgoCD sync issue

--- a/kubernetes/infrastructure/keycloak/base/kustomization.yaml
+++ b/kubernetes/infrastructure/keycloak/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ns.yaml
   - keycloak-env-externalsecret.yaml
   - keycloak-externalsecret.yaml
+  - keycloak-db-externalsecret.yaml
 
 # Generate keycloak config realm
 configMapGenerator:

--- a/kubernetes/infrastructure/keycloak/base/kustomization.yaml
+++ b/kubernetes/infrastructure/keycloak/base/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: keycloak
 
 resources:
   - ns.yaml
+  - minio-externalsecret.yaml
   - keycloak-env-externalsecret.yaml
   - keycloak-externalsecret.yaml
   - keycloak-db-externalsecret.yaml

--- a/kubernetes/infrastructure/keycloak/base/minio-externalsecret.yaml
+++ b/kubernetes/infrastructure/keycloak/base/minio-externalsecret.yaml
@@ -1,0 +1,31 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: minio-externalsecret
+  namespace: keycloak
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: keycloak-minio-secret
+    template:
+      engineVersion: v2
+      data:
+        AWS_ENDPOINTS: "https://s3.ricsanfre.com:9091"
+        AWS_ACCESS_KEY_ID: "{{ .user | toString }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .key | toString }}"
+  data:
+  - secretKey: user
+    remoteRef:
+      key: minio/barman
+      property: user
+      conversionStrategy: Default # ArgoCD sync issue
+      decodingStrategy: None # ArgoCD sync issue
+      metadataPolicy: None # ArgoCD sync issue
+  - secretKey: key
+    remoteRef:
+      key: minio/barman
+      property: key
+      conversionStrategy: Default # ArgoCD sync issue
+      decodingStrategy: None # ArgoCD sync issue
+      metadataPolicy: None # ArgoCD sync issue

--- a/kubernetes/infrastructure/keycloak/base/values.yaml
+++ b/kubernetes/infrastructure/keycloak/base/values.yaml
@@ -15,17 +15,18 @@ auth:
   existingSecret: keycloak-secret
   adminUser: admin
 
-# postgresSQL
+
+# External DB: https://github.com/bitnami/charts/tree/main/bitnami/keycloak#use-an-external-database
 postgresql:
-  enabled: true
-  auth:
-    username: keycloak
-    database: keycloak
-    existingSecret: keycloak-secret
-    secretKeys:
-      adminPasswordKey: postgresql-admin-password
-      userPasswordKey: password
-  architecture: standalone
+  enabled: false
+
+externalDatabase:
+  host: "keycloak-db-rw"
+  port: 5432
+  database: keycloak
+  existingSecret: "keycloak-db-secret"
+  existingSecretUserKey: "username"
+  existingSecretPasswordKey: "password"
 
 # Adding additional secrets for realm configuration as environment variables
 extraEnvVarsSecret: keycloak-env-secret


### PR DESCRIPTION
- New databases application to deploy cloudnative-pg and mongodb operators.
- Reconfigure keycloak to use external PosgreSQL database created by cloudNative-PG
- Deploy Keycloak database in HA
- Configure Keycloak database backup to external Minio server
