### PR TITLE
get KUBERNETES_HOST in case multiple contextx exist in vault docs

### DIFF
--- a/docs/_docs/vault.md
+++ b/docs/_docs/vault.md
@@ -663,8 +663,12 @@ Enabling [Vault kubernetes auth method](https://developer.hashicorp.com/vault/do
   # Get Kubernetes CA
   kubectl config view --raw --minify --flatten --output='jsonpath={.clusters[].cluster.certificate-authority-data}' | base64 --decode > k3s_ca.crt
 
-  # Get Kubernetes Url
+  # Get Kubernetes Url when using just one context of one cluster
   KUBERNETES_HOST=$(kubectl config view -o jsonpath='{.clusters[].cluster.server}')
+
+  # Get Kubernetes Url of the actual cluster context using, in case there are multiples
+  KUBERNETES_HOST=$(kubectl config view --minify --flatten --output='jsonpath={.clusters[0].cluster.server}')
+  
   ```
 
 - Step 7. Enable Kubernetes auth method


### PR DESCRIPTION
The actual way of getting the host ip is:
`KUBERNETES_HOST=$(kubectl config view -o jsonpath='{.clusters[].cluster.server}')`
which is fine when just one context exist in the config, but it may return the wrong ip when using multiple.

Add an option in case there are multiple clusters contexts in the config
`KUBERNETES_HOST=$(kubectl config view --minify --flatten --output='jsonpath={.clusters[0].cluster.server}')`