### PR TITLE
fix(cilium): k3s has an API server proxy at `127.0.0.1:6444`

### DIFF
--- a/kubernetes/platform/cilium/app/base/values.yaml
+++ b/kubernetes/platform/cilium/app/base/values.yaml
@@ -18,8 +18,8 @@ operator:
 rollOutCiliumPods: true
 
 # K8s API service
-k8sServiceHost: 10.0.0.11
-k8sServicePort: 6443
+k8sServiceHost: 127.0.0.1
+k8sServicePort: 6444
 
 # Replace Kube-proxy
 kubeProxyReplacement: true


### PR DESCRIPTION
There is no need to use an external LB or something like kube-vip for this Cilium config, k3s has an API server proxy listening in `127.0.0.1:6444` on all nodes in the cluster. I ran with this setup in the https://github.com/onedr0p/cluster-template back when using k3s so just sharing some knowledge to here.

There is no special k3s setting to turn this on, it's there by default.