### PR TITLE
Feature: Activate K3s embedded Spegel

### DIFF
--- a/ansible/roles/k3s/master/defaults/main.yml
+++ b/ansible/roles/k3s/master/defaults/main.yml
@@ -7,7 +7,10 @@ k3s_token: s1cret0
 k3s_version: v1.24.7+k3s1
 
 # k3s config file
-k3s_config_file: /etc/rancher/k3s/config.yaml
+k3s_config_file: "{{ k3s_config_dir }}/config.yaml"
+
+# k3s registries file
+k3s_registries_file: "{{ k3s_config_dir }}/registries.yaml"
 
 # k3s kubelet config content
 k3s_kubelet_config: ""

--- a/ansible/roles/k3s/master/tasks/pre_configuration.yml
+++ b/ansible/roles/k3s/master/tasks/pre_configuration.yml
@@ -41,3 +41,9 @@
     src: "templates/config.yml.j2"
     dest: "{{ k3s_config_file }}"
     mode: 0644
+
+- name: Ensure containerd registries file exists
+  ansible.builtin.template:
+    src: "templates/registry.yml.j2"
+    dest: "{{ k3s_registries_file }}"
+    mode: 0600

--- a/ansible/roles/k3s/master/templates/registry.yml.j2
+++ b/ansible/roles/k3s/master/templates/registry.yml.j2
@@ -1,0 +1,2 @@
+---
+{{ k3s_registries | to_nice_yaml(indent=2) }}

--- a/ansible/roles/k3s/master/vars/main.yml
+++ b/ansible/roles/k3s/master/vars/main.yml
@@ -5,7 +5,7 @@ k3s_primary_control_node: false
 
 
 # Config directory location for k3s
-k3s_config_dir: "{{ k3s_config_file | dirname }}"
+k3s_config_dir: "/etc/rancher/k3s"
 
 # Directory for gathering the k3s token for clustering.
 k3s_token_file: "{{ k3s_config_dir }}/cluster-token"

--- a/ansible/roles/k3s/worker/defaults/main.yml
+++ b/ansible/roles/k3s/worker/defaults/main.yml
@@ -4,7 +4,10 @@
 k3s_token: s1cret0
 
 # k3s config file
-k3s_config_file: /etc/rancher/k3s/config.yaml
+k3s_config_file: "{{ k3s_config_dir }}/config.yaml"
+
+# k3s registries file
+k3s_registries_file: "{{ k3s_config_dir }}/registries.yaml"
 
 # k3s agent config
 k3s_agent_config: ""

--- a/ansible/roles/k3s/worker/tasks/pre_configuration.yml
+++ b/ansible/roles/k3s/worker/tasks/pre_configuration.yml
@@ -27,3 +27,9 @@
     src: "templates/config.yml.j2"
     dest: "{{ k3s_config_file }}"
     mode: 0644
+
+- name: Ensure containerd registries file exists
+  ansible.builtin.template:
+    src: "templates/registry.yml.j2"
+    dest: "{{ k3s_registries_file }}"
+    mode: 0600

--- a/ansible/roles/k3s/worker/templates/registry.yml.j2
+++ b/ansible/roles/k3s/worker/templates/registry.yml.j2
@@ -1,0 +1,2 @@
+---
+{{ k3s_registries | to_nice_yaml(indent=2) }}

--- a/ansible/roles/k3s/worker/vars/main.yml
+++ b/ansible/roles/k3s/worker/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 
 # Config directory location for k3s
-k3s_config_dir: "{{ k3s_config_file | dirname }}"
+k3s_config_dir: "/etc/rancher/k3s"
 
 # Directory for gathering the k3s token for clustering.
 k3s_token_file: "{{ k3s_config_dir }}/cluster-token"

--- a/ansible/vars/picluster.yml
+++ b/ansible/vars/picluster.yml
@@ -52,6 +52,9 @@ k3s_server_config:
   disable-helm-controller: true
   # Disable kube-proxy (using cilium kube-proxy replacement)
   disable-kube-proxy: true
+  # Enabling Embedded Registry Mirror (Spegel)
+  embedded-registry: true
+  # TLS config
   tls-san:
     - "{{ k3s_api_vip }}"  # IP to HAProxy
   # Disable K3s addons: coredns, local path, servicelb, traefik and metric-server
@@ -87,6 +90,10 @@ k3s_agent_config:
     - 'config=/etc/rancher/k3s/kubelet.config'
 #  kube-proxy-arg:
 #    - 'metrics-bind-address=0.0.0.0'
+
+k3s_registries:
+  mirrors:
+    "*":
 
 
 ##########


### PR DESCRIPTION
# Feature Scope

[Spegel](https://spegel.dev/) is a stateless distributed OCI registry mirror that allows peer-to-peer sharing of container images between nodes in a Kubernetes cluster.

Spegel enables each node in a Kubernetes cluster to act as a local registry mirror, allowing nodes to share images between themselves. Any image already pulled by a node will be available for any other node in the cluster to pull. This has the benefit of reducing workload startup times and egress traffic as images will be stored locally within the cluster

Spegel is embedded in k3s distribution  as add-on service, but disabled by default. See further details in [K3S - Embedded Mirror Registry](https://docs.k3s.io/installation/registry-mirror).

This feature scope is to install K3S with Embedded Registry Mirror (Spegel) activated, so images pulling process can be speed-up