### PR TITLE
docs: fix typo in Cluster Gateway (OpenWrt) page

### DIFF
--- a/docs/_docs/openwrt.md
+++ b/docs/_docs/openwrt.md
@@ -146,7 +146,7 @@ ssh root@10.0.0.1 -i <ssh_private_key_file>
 
 - Go to System -> Administrator
 - Select "SSH Access" tab
-  - Unchek "Password Authentication" and "Allows root login with password"
+  - Uncheck "Password Authentication" and "Allows root login with password"
 
   ![openwrt-ssh-disable-password-access](/assets/img/openwrt-ssh-disable-password-access.png)
 


### PR DESCRIPTION
Hello,

Thank you for this great repository on setting up a Pi cluster!
It contains a wealth of valuable resources, and I’m learning a lot by reading through the documentation and following along.

While going through the docs, I noticed a small typo and wanted to submit this PR to help correct it.
Thanks again for the excellent work!