### PR TITLE
Automate openWRT TLS certificate deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@
 /ansible/.uv-cache
 
 # Metal
-/metal/openwrt
+/metal/openwrt/config
 
 # IDE
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,7 @@ external-services-reset: ## Reset external services
 
 openwrt-certbot-tls: ## Generate gateway TLS certificate via certbot
 	$(RUNNER) ansible-playbook generate_gateway_tls_certificate.yml
+	./metal/openwrt/script/openwrt-deploy-tls.sh
 
 deploy-monitoring-agent: ## Deploy monitoring agent
 	$(RUNNER) ansible-playbook deploy_monitoring_agent.yml

--- a/metal/openwrt/script/openwrt-deploy-tls.sh
+++ b/metal/openwrt/script/openwrt-deploy-tls.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# openwrt-deploy-tls.sh
+# Deploy renewed Let's Encrypt cert to OpenWRT gateway if changed
+
+set -euo pipefail
+
+CERT_PATH="$HOME/.certbot/config/live/gateway.homelab.ricsanfre.com/fullchain.pem"
+KEY_PATH="$HOME/.certbot/config/live/gateway.homelab.ricsanfre.com/privkey.pem"
+REMOTE_HOST="gateway"
+REMOTE_CERT="/etc/uhttpd.crt"
+REMOTE_KEY="/etc/uhttpd.key"
+REMOTE_SERVICE="/etc/init.d/uhttpd"
+
+# Get current checksum (empty if file does not exist)
+old_cert_sum=$(ssh "$REMOTE_HOST" "[ -f $REMOTE_CERT ] && sha256sum $REMOTE_CERT | awk '{print \$1}' || echo -n ''")
+old_key_sum=$(ssh "$REMOTE_HOST" "[ -f $REMOTE_KEY ] && sha256sum $REMOTE_KEY | awk '{print \$1}' || echo -n ''")
+
+echo "[INFO] Current remote cert checksum: $old_cert_sum"
+echo "[INFO] Current remote key checksum: $old_key_sum"
+
+# Get new checksum
+new_cert_sum=$(sha256sum "$CERT_PATH" | awk '{print $1}')
+new_key_sum=$(sha256sum "$KEY_PATH" | awk '{print $1}')
+
+echo "[INFO] New cert checksum: $new_cert_sum"
+echo "[INFO] New key checksum: $new_key_sum"
+
+# Only deploy if changed
+if [[ "$old_cert_sum" != "$new_cert_sum" ]] || [[ "$old_key_sum" != "$new_key_sum" ]]; then
+  echo "[INFO] Certificate or key changed, deploying to $REMOTE_HOST..."
+  scp -O "$KEY_PATH" "$REMOTE_HOST:$REMOTE_KEY"
+  scp -O "$CERT_PATH" "$REMOTE_HOST:$REMOTE_CERT"
+  ssh "$REMOTE_HOST" "$REMOTE_SERVICE restart"
+  echo "[INFO] Deployment complete."
+else
+  echo "[INFO] Certificate and key unchanged. No deployment needed."
+fi


### PR DESCRIPTION
This pull request streamlines the process of deploying renewed TLS certificates to the OpenWRT gateway. It introduces a new deployment script and integrates it into the existing Makefile workflow, ensuring that the gateway's certificates are only updated when changes are detected.

**TLS Certificate Deployment Automation:**

* Added a new script `openwrt-deploy-tls.sh` that checks whether the Let's Encrypt TLS certificate or private key has changed, and if so, securely copies them to the OpenWRT gateway and restarts the relevant service.
* Updated the `Makefile` target `openwrt-certbot-tls` to invoke the new deployment script after generating the certificate, automating the deployment step.