### PR TITLE
Fixing typo: cillium -> cilium in dev.md

### DIFF
--- a/docs/_docs/dev.md
+++ b/docs/_docs/dev.md
@@ -202,7 +202,7 @@ Follow official [kubectl installation guide](https://kubernetes.io/docs/tasks/to
 
 k3s cluster can be created using K3D. The cluster will be configured with same options as production environment:
 
-- CNI cillium is used, instead of default Flannel
+- CNI cilium is used, instead of default Flannel
 - All K3s add-ons are not installed (traefik, helmcontroller, localpath, coredns, etc.)
 - kube-proxy is disabled (Cilium Kube-proxy replacement feature will be used)
 - Cilium L2 LB announcement will be used


### PR DESCRIPTION
Small documentation fix: corrects a typo in `docs/_docs/dev.md` (line 205) where `cillium` should be `cilium`.

The rest of the file already uses "Cilium" / "cilium" correctly (e.g. lines 13, 14, 207, 215, 368, 388, 393, 396), so this change makes the document consistent. No other files contain this misspelling.