### PR TITLE
feat(e-commerce): adapt OTEL APM dashboard and add pipeline labels for e-commerce

### DIFF
--- a/kubernetes/apps/e-commerce/config/monitoring/apm-dashboard.json
+++ b/kubernetes/apps/e-commerce/config/monitoring/apm-dashboard.json
@@ -2011,7 +2011,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(target_info{\"deployment.environment.name\"=~\"$deployment_environment_name\", \"telemetry.sdk.name\"=~\"\\\\S.*\"},\"service.namespace\")",
+        "definition": "label_values(target_info{\"deployment.environment.name\"=~\"$deployment_environment_name\",\"service.name\"=~\".+\"}, \"service.namespace\")",
         "description": "Service namespace.\nResource attribute `service.namespace` via `target_info`.\nValue `<<not defined>>` when the resource attribute `service.namespace` is not set.",
         "includeAll": false,
         "label": "Namespace",
@@ -2019,7 +2019,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(target_info{\"deployment.environment.name\"=~\"$deployment_environment_name\", \"telemetry.sdk.name\"=~\"\\\\S.*\"},\"service.namespace\")",
+          "query": "label_values(target_info{\"deployment.environment.name\"=~\"$deployment_environment_name\",\"service.name\"=~\".+\"}, \"service.namespace\")",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -2042,14 +2042,14 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(target_info{\"service.namespace\"=~\"$service_namespace\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"telemetry.sdk.name\"=~\"\\\\S.*\"},\"service.name\")",
+        "definition": "label_values(target_info{\"service.namespace\"=~\"$service_namespace\",\"deployment.environment.name\"=~\"$deployment_environment_name\",\"service.name\"=~\".+\"}, \"service.name\")",
         "description": "Service name.\nResource attribute `service.name` via `target_info`.",
         "label": "Service",
         "name": "service_name",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(target_info{\"service.namespace\"=~\"$service_namespace\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"telemetry.sdk.name\"=~\"\\\\S.*\"},\"service.name\")",
+          "query": "label_values(target_info{\"service.namespace\"=~\"$service_namespace\",\"deployment.environment.name\"=~\"$deployment_environment_name\",\"service.name\"=~\".+\"}, \"service.name\")",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,

--- a/kubernetes/apps/e-commerce/config/monitoring/apm-dashboard.json
+++ b/kubernetes/apps/e-commerce/config/monitoring/apm-dashboard.json
@@ -1,0 +1,2084 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "APM dashboard for e-commerce microservices (Spring Boot + Next.js). Uses Tempo for traces, Prometheus for metrics, and Elasticsearch for logs. Adapted from the original OpenTelemetry Demo APM dashboard.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "description": "service.namespace=${service_namespace}, service.name=${service_name}, deployment.environment.name=${deployment_environment_name}",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 10,
+        "x": 0,
+        "y": 0
+      },
+      "id": 20,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<h1><img src=\"https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png\" alt=\"OpenTelemetry Icon\" width=\"25\" height=\"\"> Service ${service_namespace}/${service_name}</h1>\n<p>Environment: <code>${deployment_environment_name}</code></p>",
+        "mode": "html"
+      },
+      "pluginVersion": "12.2.0",
+      "title": "",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Shows the timestamp of the latest metrics received in the past 24h.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#24292e",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 3,
+        "x": 10,
+        "y": 0
+      },
+      "hideTimeOverride": true,
+      "id": 39,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^Time$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "timestamp(sum by (\"deployment.environment.name\", \"service.namespace\", \"service.name\") (target_info{\"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}) or absent{})\n",
+          "interval": "60s",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "timeFrom": "now-24h",
+      "title": "Latest metrics received",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Server RED Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "HTTP & RPC endpoints aggregation on the `http.server.request.duration` & `rpc.server.duration` metrics.\n\nSee https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration and https://opentelemetry.io/docs/specs/semconv/rpc/rpc-metrics/#metric-rpcserverduration",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 10,
+              "type": "log"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "No HTTP or RPC operation",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 0,
+        "y": 3
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(\n  0.95,\n  sum by (le, \"deployment.environment.name\", \"service.namespace\", \"service.name\") (\n    rate(\n      {\"http.server.request.duration_seconds_bucket\",\n        \"deployment.environment.name\"=~\"$deployment_environment_name\",\n        \"service.namespace\"=~\"$service_namespace\",\n        \"service.name\"=\"$service_name\"\n      }[$__rate_interval]\n    )\n  )\n)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "interval": "60s",
+          "legendFormat": "HTTP p95",
+          "range": true,
+          "refId": "HTTP P95",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "avg by (\"deployment.environment.name\", \"service.namespace\", \"service.name\") (\n  rate(\n    {\"http.server.request.duration_seconds_sum\",\n      \"deployment.environment.name\"=~\"$deployment_environment_name\",\n      \"service.namespace\"=~\"$service_namespace\",\n      \"service.name\"=\"$service_name\"\n    }[$__rate_interval]\n  )\n)\n/\navg by (\"deployment.environment.name\", \"service.namespace\", \"service.name\") (\n  rate(\n    {\"http.server.request.duration_seconds_count\",\n      \"deployment.environment.name\"=~\"$deployment_environment_name\",\n      \"service.namespace\"=~\"$service_namespace\",\n      \"service.name\"=\"$service_name\"\n    }[$__rate_interval]\n  )\n)",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "interval": "60s",
+          "legendFormat": "HTTP avg",
+          "range": true,
+          "refId": "HTTP AVG",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(\n  0.95,\n  sum by (le, \"deployment.environment.name\", \"service.namespace\", \"service.name\") (\n    rate(\n      {\"rpc.server.duration_milliseconds_bucket\",\n        \"deployment.environment.name\"=~\"$deployment_environment_name\",\n        \"service.namespace\"=~\"$service_namespace\",\n        \"service.name\"=\"$service_name\"\n      }[$__rate_interval]\n    ) / 1000\n  )\n)",
+          "hide": false,
+          "instant": false,
+          "interval": "60",
+          "legendFormat": "RPC p95",
+          "range": true,
+          "refId": "RPC P95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg by (\"deployment.environment.name\", \"service.namespace\", \"service.name\") (\n  rate(\n    {\"rpc.server.duration_milliseconds_sum\",\n      \"deployment.environment.name\"=~\"$deployment_environment_name\",\n      \"service.namespace\"=~\"$service_namespace\",\n      \"service.name\"=\"$service_name\"\n    }[$__rate_interval]\n  ) / 1000\n)\n/\navg by (\"deployment.environment.name\", \"service.namespace\", \"service.name\") (\n  rate(\n    {\"rpc.server.duration_milliseconds_count\",\n      \"deployment.environment.name\"=~\"$deployment_environment_name\",\n      \"service.namespace\"=~\"$service_namespace\",\n      \"service.name\"=\"$service_name\"\n    }[$__rate_interval]\n  )\n)",
+          "hide": false,
+          "instant": false,
+          "interval": "60",
+          "legendFormat": "RPC avg",
+          "range": true,
+          "refId": "RPC AVG"
+        }
+      ],
+      "title": "Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "HTTP and RPC endpoints aggregation on the `http.server.request.duration` and `rpc.server.duration` metrics. \n\nErrors are identified by : \n* `http.response.status_code=~\"5..\"`\n* `rpc.grpc.status_code!=\"0\"`\n\nSee https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration\n",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 100,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "noValue": "No HTTP or RPC operation",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 5,
+        "y": 3
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "(\n    (sum by(\"deployment.environment.name\", \"service.namespace\", \"service.name\") (rate({\"http.server.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\", \"http.response.status_code\"=~\"5..\"}[$__rate_interval])) * 100) \n    / \n    sum by(\"deployment.environment.name\", \"service.namespace\", \"service.name\") (rate({\"http.server.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]))\n)\nor\n(\n    0\n    * \n    sum by(\"deployment.environment.name\", \"service.namespace\", \"service.name\") (rate({\"http.server.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]))\n)",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "60s",
+          "legendFormat": "HTTP 5xx errors",
+          "range": true,
+          "refId": "HTTP 5xx",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "((sum without (\"rpc.grpc.status_code\", instance) (rate({\"rpc.server.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\", \"rpc.grpc.status_code\"!=\"0\"}[$__rate_interval])) * 100) / sum without (\"rpc.grpc.status_code\", instance) (rate({\"rpc.server.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval])))\nor\n(0 * sum without (\"rpc.grpc.status_code\", instance) (rate({\"rpc.server.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval])))",
+          "hide": false,
+          "instant": false,
+          "interval": "60",
+          "legendFormat": "RPC errors",
+          "range": true,
+          "refId": "RPC Err"
+        }
+      ],
+      "title": "Error",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "HTTP & RPC endpoints aggregation on the `http.server.request.duration` & `rpc.server.duration` metrics.\n\nSee https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 10,
+              "type": "log"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "No HTTP or RPC operation",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 10,
+        "y": 3
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "(sum(rate({\"http.server.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval])) by (\"deployment.environment.name\", \"service.namespace\", \"service.name\")) ",
+          "hide": false,
+          "instant": false,
+          "interval": "60s",
+          "legendFormat": "HTTP requests",
+          "range": true,
+          "refId": "HTTP RPS"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(sum(rate({\"rpc.server.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval])) by (\"deployment.environment.name\", \"service.namespace\", \"service.name\")) * $__interval_ms / 1000",
+          "hide": false,
+          "instant": false,
+          "interval": "60",
+          "legendFormat": "RPC requests",
+          "range": true,
+          "refId": "RPC RPS"
+        }
+      ],
+      "title": "Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 15,
+        "y": 3
+      },
+      "id": 40,
+      "options": {
+        "alertInstanceLabelFilter": "{\"service.name\"=\"$service_name\", \"service.namespace\"=\"$service_namespace\"}",
+        "alertName": "",
+        "dashboardAlerts": false,
+        "groupBy": [],
+        "groupMode": "default",
+        "maxItems": 20,
+        "showInactiveAlerts": false,
+        "sortOrder": 1,
+        "stateFilter": {
+          "error": true,
+          "firing": true,
+          "noData": false,
+          "normal": false,
+          "pending": true,
+          "recovering": true
+        },
+        "viewMode": "list"
+      },
+      "pluginVersion": "12.2.0",
+      "title": "Alerts",
+      "type": "alertlist"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Inbound HTTP operations of the service (aka HTTP endpoints) based on the `http.server.request.duration` metric.\n\nErrors are identified by `http.response.status_code=~\"5..\"`.\n\nSee https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "noValue": "No HTTP operation",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Duration (p99)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Rate"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "reqps"
+              },
+              {
+                "id": "custom.width",
+                "value": 219
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Error"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 21,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Operation"
+          }
+        ]
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "\n        sum by (operation) (\n            label_join(\n                rate({\"http.server.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"operation\",\n                \" \",\n                \"http.request.method\",\n                \"http.route\"\n            )\n        )\n    ",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "interval": "60s",
+          "legendFormat": "{{operation}}",
+          "range": true,
+          "refId": "RPS",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(\n        sum by (operation) (\n            label_join(\n                rate({\"http.server.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\", \"http.response.status_code\"=~\"5..\"}[$__rate_interval]),\n                \"operation\",\n                \" \",\n                \"http.request.method\",\n                \"http.route\"\n            )\n        )\n     / \n        sum by (operation) (\n            label_join(\n                rate({\"http.server.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"operation\",\n                \" \",\n                \"http.request.method\",\n                \"http.route\"\n            )\n        )\n    ) or (0 * \n        sum by (operation) (\n            label_join(\n                rate({\"http.server.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"operation\",\n                \" \",\n                \"http.request.method\",\n                \"http.route\"\n            )\n        )\n    )",
+          "hide": false,
+          "instant": false,
+          "interval": "60s",
+          "legendFormat": "{{operation}}",
+          "range": true,
+          "refId": "ERR_PCT"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "\n        histogram_quantile(\n            0.99,\n            sum by (le, operation) (\n                label_join(\n                rate({\"http.server.request.duration_seconds_bucket\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[5m]),\n                \"operation\",\n                \" \",\n                \"http.request.method\",\n                \"http.route\"\n                )\n            )\n        )\n    ",
+          "hide": false,
+          "instant": false,
+          "interval": "60s",
+          "legendFormat": "{{operation}}",
+          "range": true,
+          "refId": "Duration"
+        }
+      ],
+      "title": "HTTP Operations",
+      "transformations": [
+        {
+          "id": "timeSeriesTable",
+          "options": {
+            "Duration": {
+              "timeField": "Time"
+            },
+            "ERR_PCT": {
+              "timeField": "Time"
+            },
+            "RPS": {
+              "timeField": "Time"
+            }
+          }
+        },
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "operation",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "Trend #Duration": 1,
+              "Trend #ERR_PCT": 2,
+              "Trend #RPS": 3,
+              "operation": 0
+            },
+            "renameByName": {
+              "Trend #Duration": "Duration (p99)",
+              "Trend #ERR_PCT": "Error",
+              "Trend #RPS": "Rate",
+              "operation": "Operation"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Inbound gRPC operations of the service (aka gRPC endpoints) based on the `rpc.server.request.duration` metric.\n\nErrors are identified by `rpc.grpc.status_code != 0` which make the panel specific to the gRPC protocol.\n\nhttps://opentelemetry.io/docs/specs/semconv/rpc/rpc-metrics/#metric-rpcserverduration",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "noValue": "No RPC operation",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Duration (p99)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Rate"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "reqps"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Error"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 27,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Operation"
+          }
+        ]
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "\nsum by (operation) (\n    label_join(\n        rate({\"rpc.server.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n        \"operation\",\n        \"/\",\n        \"rpc.service\",\n        \"rpc.method\"\n    )\n)\n    ",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "interval": "60s",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "RPS",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(\n        sum by (operation) (\n            label_join(\n                rate({\"rpc.server.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\", \"rpc.grpc.status_code\"!=\"0\"}[$__rate_interval]),\n                \"operation\",\n                \"/\",\n                \"rpc.service\",\n                \"rpc.method\"\n            )\n        )\n     / \n        sum by (operation) (\n            label_join(\n                rate({\"rpc.server.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"operation\",\n                \"/\",\n                \"rpc.service\",\n                \"rpc.method\"\n            )\n        )\n    ) or (0 * \n        sum by (operation) (\n            label_join(\n                rate({\"rpc.server.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"operation\",\n                \"/\",\n                \"rpc.service\",\n                \"rpc.method\"\n            )\n        )\n    )\n    ",
+          "hide": false,
+          "instant": false,
+          "interval": "60s",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "ERR_PCT"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "\n        histogram_quantile(\n            0.99,\n            sum by (le, operation) (\n                label_join(\n                rate({\"rpc.server.duration_milliseconds_bucket\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[5m]),\n                \"operation\",\n                \"/\",\n                \"rpc.service\",\n                \"rpc.method\"\n                )\n            )\n        )\n    ",
+          "hide": false,
+          "instant": false,
+          "interval": "60s",
+          "legendFormat": "{{operation}}",
+          "range": true,
+          "refId": "Duration"
+        }
+      ],
+      "title": "gRPC Operations",
+      "transformations": [
+        {
+          "id": "timeSeriesTable",
+          "options": {
+            "Duration": {
+              "timeField": "Time"
+            },
+            "ERR_PCT": {
+              "timeField": "Time"
+            },
+            "RPS": {
+              "timeField": "Time"
+            }
+          }
+        },
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "operation",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "Trend #Duration": 1,
+              "Trend #ERR_PCT": 2,
+              "Trend #RPS": 3,
+              "operation": 0
+            },
+            "renameByName": {
+              "Trend #Duration": "Duration (p99)",
+              "Trend #ERR_PCT": "Error",
+              "Trend #RPS": "Rate",
+              "operation": "Operation"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 28,
+      "panels": [],
+      "title": "Outbound Services and Databases",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "HTTP calls made by the service based on the `http.client.request.duration` metric.\n\nCalls broken done by remote `server.address` and by `http.request.method`.\n\nSee https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpclientrequestduration",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "noValue": "No HTTP call",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Duration (P99)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Rate"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "reqps"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Error"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 23,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "\n        sum by (outbound_service) (\n            label_join(\n                rate({\"http.client.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"outbound_service\",\n                \" \",\n                \"server.address\",\n                \"http.request.method\",\n                \"url.template\"\n            )\n        )\n    ",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "interval": "60s",
+          "legendFormat": "{{server.address}} {{http.request.method}} {{url.template}}",
+          "range": true,
+          "refId": "RPS",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(\n        sum by (outbound_service) (\n            label_join(\n                rate({\"http.client.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\", \"http.response.status_code\"=~\"5..\"}[$__rate_interval]),\n                \"outbound_service\",\n                \" \",\n                \"server.address\",\n                \"http.request.method\",\n                \"url.template\"\n            )\n        )\n     / \n        sum by (outbound_service) (\n            label_join(\n                rate({\"http.client.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"outbound_service\",\n                \" \",\n                \"server.address\",\n                \"http.request.method\",\n                \"url.template\"\n            )\n        )\n    ) or (0 * \n        sum by (outbound_service) (\n            label_join(\n                rate({\"http.client.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"outbound_service\",\n                \" \",\n                \"server.address\",\n                \"http.request.method\",\n                \"url.template\"\n            )\n        )\n    )",
+          "hide": false,
+          "instant": false,
+          "interval": "60s",
+          "legendFormat": "{{server.address}} {{http.request.method}} {{url.template}}",
+          "range": true,
+          "refId": "ERR_PCT"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "\nhistogram_quantile(\n    0.99,\n    sum by (le, outbound_service) (\n        label_join(\n        rate({\"http.client.request.duration_seconds_bucket\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[5m]),\n        \"outbound_service\",\n        \" \",\n        \"server.address\",\n        \"http.request.method\",\n        \"url.template\"\n        )\n    )\n)",
+          "hide": false,
+          "instant": false,
+          "interval": "60s",
+          "legendFormat": "{{server.address}} {{http.request.method}} {{url.template}}",
+          "range": true,
+          "refId": "DURATION"
+        }
+      ],
+      "title": "Outbound HTTP Services",
+      "transformations": [
+        {
+          "id": "timeSeriesTable",
+          "options": {
+            "Duration": {
+              "timeField": "Time"
+            },
+            "ERR_PCT": {
+              "timeField": "Time"
+            },
+            "RPS": {
+              "timeField": "Time"
+            }
+          }
+        },
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "outbound_service",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "Trend #DURATION": 1,
+              "Trend #ERR_PCT": 2,
+              "Trend #RPS": 3,
+              "outbound_service": 0
+            },
+            "renameByName": {
+              "Trend #DURATION": "Duration (P99)",
+              "Trend #Duration": "Duration (p99)",
+              "Trend #ERR_PCT": "Error",
+              "Trend #RPS": "Rate",
+              "operation": "Operation",
+              "outbound_service": "Service"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "DB calls made by the service based on the `db.client.operation.duration` metric.\n\nCalls broken down by `server.address` and `db.namespace`.\n\nSee https://opentelemetry.io/docs/specs/semconv/database/database-metrics/#metric-dbclientoperationduration\n",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "noValue": "No database call",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Duration (P99)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Rate"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "reqps"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Error"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 24,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by (database) (\n    label_join(\n        rate({\"db.client.operation.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n        \"database\",\n        \"/\",\n        \"server.address\",\n        \"db.namespace\"\n    )\n)\n    ",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "interval": "60s",
+          "legendFormat": "{{server.address}} {{db.namespace}}",
+          "range": true,
+          "refId": "RPS",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(\n        sum by (database) (\n            label_join(\n                rate({\"db.client.operation.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\", \"http.response.status_code\"=~\"5..\"}[$__rate_interval]),\n                \"database\",\n                \"/\",\n                \"server.address\",\n                \"db.namespace\"\n            )\n        )\n     / \n        sum by (database) (\n            label_join(\n                rate({\"db.client.operation.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"database\",\n                \"/\",\n                \"server.address\",\n                \"db.namespace\"\n            )\n        )\n    ) or (0 * \n        sum by (database) (\n            label_join(\n                rate({\"db.client.operation.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"database\",\n                \"/\",\n                \"server.address\",\n                \"db.namespace\"\n            )\n        )\n    )",
+          "hide": false,
+          "instant": false,
+          "interval": "60s",
+          "legendFormat": "{{server.address}} {{db.namespace}}",
+          "range": true,
+          "refId": "ERR_PCT"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "\nhistogram_quantile(\n    0.99,\n    sum by (le, database) (\n        label_join(\n        rate({\"db.client.operation.duration_seconds_bucket\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[5m]),\n            \"database\",\n            \"/\",\n            \"server.address\",\n            \"db.namespace\"\n        )\n    )\n)",
+          "hide": false,
+          "instant": false,
+          "interval": "60s",
+          "legendFormat": "{{server.address}} {{db.namespace}}",
+          "range": true,
+          "refId": "DURATION"
+        }
+      ],
+      "title": "Outbound Databases",
+      "transformations": [
+        {
+          "id": "timeSeriesTable",
+          "options": {
+            "DURATION": {
+              "timeField": "Time"
+            },
+            "Duration": {
+              "timeField": "Time"
+            },
+            "ERR_PCT": {
+              "timeField": "Time"
+            },
+            "RPS": {
+              "timeField": "Time"
+            }
+          }
+        },
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "database",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "Trend #DURATION": 1,
+              "Trend #ERR_PCT": 2,
+              "Trend #RPS": 3,
+              "database": 0
+            },
+            "renameByName": {
+              "Trend #DURATION": "Duration (P99)",
+              "Trend #Duration": "Duration (p99)",
+              "Trend #ERR_PCT": "Error",
+              "Trend #RPS": "Rate",
+              "database": "Database",
+              "database_operation": "Database Operation",
+              "operation": "Operation",
+              "outbound_service": "Service"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "gRPC calls made by the service based on the `rpc.client.request.duration` metric.\n\nSpecific to gRPC due to the usage of the `grpc.status.code` attribute to identify errors.\n\nCalls broken down by `server.address`, `rpc.service`, and `rpc.method`.\n\nSee https://opentelemetry.io/docs/specs/semconv/rpc/rpc-metrics/#rpc-client\n\n",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "noValue": "No RPC call",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Duration (P99)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Rate"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "reqps"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Error"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      },
+      "id": 32,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "\n        sum by (outbound_service) (\n            label_join(\n                rate({\"rpc.client.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"outbound_service\",\n                \"/\",\n                \"server.address\",\n                \"rpc.service\",\n                \"rpc.method\"\n            )\n        )\n    ",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "interval": "60s",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "RPS",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(\n        sum by (outbound_service) (\n            label_join(\n                rate({\"rpc.client.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\", \"http.response.status_code\"=~\"5..\"}[$__rate_interval]),\n                \"outbound_service\",\n                \"/\",\n                \"server.address\",\n                \"rpc.service\",\n                \"rpc.method\"\n            )\n        )\n     / \n        sum by (outbound_service) (\n            label_join(\n                rate({\"rpc.client.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"outbound_service\",\n                \"/\",\n                \"server.address\",\n                \"rpc.service\",\n                \"rpc.method\"\n            )\n        )\n    ) or (0 * \n        sum by (outbound_service) (\n            label_join(\n                rate({\"rpc.client.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"outbound_service\",\n                \"/\",\n                \"server.address\",\n                \"rpc.service\",\n                \"rpc.method\"\n            )\n        )\n    )",
+          "hide": false,
+          "instant": false,
+          "interval": "60s",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "ERR_PCT"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "\nhistogram_quantile(\n    0.99,\n    sum by (le, outbound_service) (\n        label_join(\n        rate({\"rpc.client.duration_milliseconds_bucket\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[5m]),\n        \"outbound_service\",\n        \"/\",\n        \"server.address\",\n        \"rpc.service\",\n        \"rpc.method\"\n        )\n    )\n)",
+          "hide": false,
+          "instant": false,
+          "interval": "60s",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "DURATION"
+        }
+      ],
+      "title": "Outbound gRPC Services",
+      "transformations": [
+        {
+          "id": "timeSeriesTable",
+          "options": {
+            "Duration": {
+              "timeField": "Time"
+            },
+            "ERR_PCT": {
+              "timeField": "Time"
+            },
+            "RPS": {
+              "timeField": "Time"
+            }
+          }
+        },
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "outbound_service",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "Trend #DURATION": 1,
+              "Trend #ERR_PCT": 2,
+              "Trend #RPS": 3,
+              "outbound_service": 0
+            },
+            "renameByName": {
+              "Trend #DURATION": "Duration (P99)",
+              "Trend #Duration": "Duration (p99)",
+              "Trend #ERR_PCT": "Error",
+              "Trend #RPS": "Rate",
+              "operation": "Operation",
+              "outbound_service": "Service Method"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 42,
+      "panels": [],
+      "title": "Infrastructure (kube-prometheus-stack)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Pod CPU and memory usage from kube-prometheus-stack (cAdvisor metrics). Filtered by K8s namespace ($service_namespace) and pods matching the selected service name ($service_name).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CPU Usage"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Memory"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decbytes"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 41,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "CPU Usage"
+          }
+        ]
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod) (\n  rate(container_cpu_usage_seconds_total{\n    namespace=~\"$service_namespace\",\n    container!=\"\",\n    image!=\"\",\n    pod=~\".*${service_name}.*\"\n  }[$__rate_interval])\n)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "cpu"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod) (\n  container_memory_working_set_bytes{\n    namespace=~\"$service_namespace\",\n    container!=\"\",\n    image!=\"\",\n    pod=~\".*${service_name}.*\"\n  }\n)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "mem"
+        }
+      ],
+      "title": "Pod Resources",
+      "transformations": [
+        {
+          "id": "timeSeriesTable",
+          "options": {
+            "cpu": {
+              "timeField": "Time"
+            },
+            "mem": {
+              "timeField": "Time"
+            }
+          }
+        },
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "pod",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Trend #cpu": "CPU Usage",
+              "Trend #mem": "Memory",
+              "pod": "Pod"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 25,
+      "panels": [],
+      "title": "Logs",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "elasticsearch",
+        "uid": "elasticsearch"
+      },
+      "description": "Logs of the selected service from Elasticsearch, adapted from the upstream OpenSearch PPL query to ES|QL.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "noValue": "No application logs",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "@timestamp"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 226
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "severity_text"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 136
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "scope.name"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 246
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 26,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "elasticsearch"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "metrics": [
+            {
+              "id": "1",
+              "type": "logs"
+            }
+          ],
+          "query": "FROM $index\n| WHERE `service.name` == \"$service_name\" AND `service.namespace` == \"$service_namespace\"\n| KEEP `@timestamp`, severity_text, `body.text`, `scope.name`\n| SORT `@timestamp` DESC\n| LIMIT 200",
+          "queryType": "esql",
+          "refId": "A"
+        }
+      ],
+      "title": "",
+      "transformations": [
+        {
+          "id": "formatTime",
+          "options": {
+            "outputFormat": "YYYY-MM-DD HH:mm:ss.SSS",
+            "timeField": "@timestamp",
+            "timezone": "browser",
+            "useTimezone": true
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "@timestamp": 0,
+              "body.text": 3,
+              "scope.name": 2,
+              "severity_text": 1
+            },
+            "renameByName": {
+              "@timestamp": "Time",
+              "body.text": "Message",
+              "scope.name": "Logger",
+              "severity_text": "Severity"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 49
+      },
+      "id": 29,
+      "panels": [],
+      "title": "Traces",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "tempo"
+      },
+      "description": "Recent traces for the selected service from Tempo, adapted from the upstream Jaeger-focused section to TraceQL.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "noValue": "No traces found",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "traceID"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 260
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "traceDuration"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 130
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 50
+      },
+      "id": 30,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Start Time"
+          }
+        ]
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "filters": [],
+          "limit": 100,
+          "query": "{ resource.service.name = \"$service_name\" && resource.service.namespace = \"$service_namespace\" }",
+          "queryType": "traceql",
+          "refId": "A",
+          "tableType": "traces"
+        }
+      ],
+      "title": "",
+      "transformations": [
+        {
+          "id": "formatTime",
+          "options": {
+            "outputFormat": "YYYY-MM-DD HH:mm:ss.SSS",
+            "timeField": "startTime",
+            "timezone": "browser",
+            "useTimezone": true
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "nested": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "startTime": 1,
+              "traceDuration": 4,
+              "traceID": 0,
+              "traceName": 3,
+              "traceService": 2
+            },
+            "renameByName": {
+              "startTime": "Start Time",
+              "traceDuration": "Duration",
+              "traceID": "Trace ID",
+              "traceName": "Root Span",
+              "traceService": "Service"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 42,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "prod",
+          "value": "prod"
+        },
+        "definition": "label_values(target_info, \"deployment.environment.name\")",
+        "description": "Deployment environment (`production`, `staging`...).\nResource attribute `deployment.environment.name` via `target_info`.\nValue `<<not defined>>` when the resource attribute `deployment.environment.name` is not set.",
+        "label": "Environment",
+        "name": "deployment_environment_name",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(target_info, \"deployment.environment.name\")",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "staticOptions": [
+          {
+            "text": "<<not defined>>",
+            "value": ""
+          }
+        ],
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "allowCustomValue": false,
+        "current": {
+          "text": "e-commerce",
+          "value": "e-commerce"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(target_info{\"deployment.environment.name\"=~\"$deployment_environment_name\", \"telemetry.sdk.name\"=~\"\\\\S.*\"},\"service.namespace\")",
+        "description": "Service namespace.\nResource attribute `service.namespace` via `target_info`.\nValue `<<not defined>>` when the resource attribute `service.namespace` is not set.",
+        "includeAll": false,
+        "label": "Namespace",
+        "name": "service_namespace",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(target_info{\"deployment.environment.name\"=~\"$deployment_environment_name\", \"telemetry.sdk.name\"=~\"\\\\S.*\"},\"service.namespace\")",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "staticOptions": [
+          {
+            "text": "<<not defined>>",
+            "value": ""
+          }
+        ],
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "frontend-service",
+          "value": "frontend-service"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(target_info{\"service.namespace\"=~\"$service_namespace\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"telemetry.sdk.name\"=~\"\\\\S.*\"},\"service.name\")",
+        "description": "Service name.\nResource attribute `service.name` via `target_info`.",
+        "label": "Service",
+        "name": "service_name",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(target_info{\"service.namespace\"=~\"$service_namespace\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"telemetry.sdk.name\"=~\"\\\\S.*\"},\"service.name\")",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "otel",
+          "value": "otel"
+        },
+        "hide": 0,
+        "label": "Log Index",
+        "name": "index",
+        "options": [],
+        "query": "otel",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "APM Dashboard - E-Commerce",
+  "uid": "e-commerce-apm",
+  "version": 1
+}

--- a/kubernetes/apps/e-commerce/config/monitoring/apm-dashboard.json
+++ b/kubernetes/apps/e-commerce/config/monitoring/apm-dashboard.json
@@ -2059,14 +2059,14 @@
       },
       {
         "current": {
-          "text": "otel",
-          "value": "otel"
+          "text": "logs-*.otel-*",
+          "value": "logs-*.otel-*"
         },
         "hide": 0,
         "label": "Log Index",
         "name": "index",
         "options": [],
-        "query": "otel",
+        "query": "logs-*.otel-*",
         "skipUrlSync": false,
         "type": "textbox"
       }

--- a/kubernetes/apps/e-commerce/config/monitoring/grafana-dashboard.yaml
+++ b/kubernetes/apps/e-commerce/config/monitoring/grafana-dashboard.yaml
@@ -2071,14 +2071,14 @@ spec:
           },
           {
             "current": {
-              "text": "otel",
-              "value": "otel"
+              "text": "logs-*.otel-*",
+              "value": "logs-*.otel-*"
             },
             "hide": 0,
             "label": "Log Index",
             "name": "index",
             "options": [],
-            "query": "otel",
+            "query": "logs-*.otel-*",
             "skipUrlSync": false,
             "type": "textbox"
           }

--- a/kubernetes/apps/e-commerce/config/monitoring/grafana-dashboard.yaml
+++ b/kubernetes/apps/e-commerce/config/monitoring/grafana-dashboard.yaml
@@ -2023,7 +2023,7 @@ spec:
               "type": "prometheus",
               "uid": "prometheus"
             },
-            "definition": "label_values(target_info{\"deployment.environment.name\"=~\"$deployment_environment_name\", \"telemetry.sdk.name\"=~\"\\\\S.*\"},\"service.namespace\")",
+            "definition": "label_values(target_info{\"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.name\"=~\".+\"},\"service.namespace\")",
             "description": "Service namespace.\nResource attribute `service.namespace` via `target_info`.\nValue `<<not defined>>` when the resource attribute `service.namespace` is not set.",
             "includeAll": false,
             "label": "Namespace",
@@ -2031,7 +2031,7 @@ spec:
             "options": [],
             "query": {
               "qryType": 1,
-              "query": "label_values(target_info{\"deployment.environment.name\"=~\"$deployment_environment_name\", \"telemetry.sdk.name\"=~\"\\\\S.*\"},\"service.namespace\")",
+              "query": "label_values(target_info{\"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.name\"=~\".+\"},\"service.namespace\")",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "refresh": 1,
@@ -2054,14 +2054,14 @@ spec:
               "type": "prometheus",
               "uid": "prometheus"
             },
-            "definition": "label_values(target_info{\"service.namespace\"=~\"$service_namespace\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"telemetry.sdk.name\"=~\"\\\\S.*\"},\"service.name\")",
+            "definition": "label_values(target_info{\"service.namespace\"=~\"$service_namespace\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.name\"=~\".+\"},\"service.name\")",
             "description": "Service name.\nResource attribute `service.name` via `target_info`.",
             "label": "Service",
             "name": "service_name",
             "options": [],
             "query": {
               "qryType": 1,
-              "query": "label_values(target_info{\"service.namespace\"=~\"$service_namespace\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"telemetry.sdk.name\"=~\"\\\\S.*\"},\"service.name\")",
+              "query": "label_values(target_info{\"service.namespace\"=~\"$service_namespace\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.name\"=~\".+\"},\"service.name\")",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "refresh": 2,

--- a/kubernetes/apps/e-commerce/config/monitoring/grafana-dashboard.yaml
+++ b/kubernetes/apps/e-commerce/config/monitoring/grafana-dashboard.yaml
@@ -9,6 +9,2088 @@ spec:
   instanceSelector:
     matchLabels:
       dashboards: grafana
-  configMapRef:
-    name: e-commerce-apm-dashboard
-    key: apm-dashboard.json
+  json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "APM dashboard for e-commerce microservices (Spring Boot + Next.js). Uses Tempo for traces, Prometheus for metrics, and Elasticsearch for logs. Adapted from the original OpenTelemetry Demo APM dashboard.",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "description": "service.namespace=${service_namespace}, service.name=${service_name}, deployment.environment.name=${deployment_environment_name}",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 10,
+            "x": 0,
+            "y": 0
+          },
+          "id": 20,
+          "options": {
+            "code": {
+              "language": "plaintext",
+              "showLineNumbers": false,
+              "showMiniMap": false
+            },
+            "content": "<h1><img src=\"https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png\" alt=\"OpenTelemetry Icon\" width=\"25\" height=\"\"> Service ${service_namespace}/${service_name}</h1>\n<p>Environment: <code>${deployment_environment_name}</code></p>",
+            "mode": "html"
+          },
+          "pluginVersion": "12.2.0",
+          "title": "",
+          "type": "text"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Shows the timestamp of the latest metrics received in the past 24h.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "#24292e",
+                "mode": "fixed"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 3,
+            "x": 10,
+            "y": 0
+          },
+          "hideTimeOverride": true,
+          "id": 39,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "/^Time$/",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "timestamp(sum by (\"deployment.environment.name\", \"service.namespace\", \"service.name\") (target_info{\"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}) or absent{})\n",
+              "interval": "60s",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "timeFrom": "now-24h",
+          "title": "Latest metrics received",
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 2
+          },
+          "id": 15,
+          "panels": [],
+          "title": "Server RED Metrics",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "HTTP & RPC endpoints aggregation on the `http.server.request.duration` & `rpc.server.duration` metrics.\n\nSee https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration and https://opentelemetry.io/docs/specs/semconv/rpc/rpc-metrics/#metric-rpcserverduration",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "log": 10,
+                  "type": "log"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "noValue": "No HTTP or RPC operation",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 0,
+            "y": 3
+          },
+          "id": 17,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "histogram_quantile(\n  0.95,\n  sum by (le, \"deployment.environment.name\", \"service.namespace\", \"service.name\") (\n    rate(\n      {\"http.server.request.duration_seconds_bucket\",\n        \"deployment.environment.name\"=~\"$deployment_environment_name\",\n        \"service.namespace\"=~\"$service_namespace\",\n        \"service.name\"=\"$service_name\"\n      }[$__rate_interval]\n    )\n  )\n)",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "interval": "60s",
+              "legendFormat": "HTTP p95",
+              "range": true,
+              "refId": "HTTP P95",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "avg by (\"deployment.environment.name\", \"service.namespace\", \"service.name\") (\n  rate(\n    {\"http.server.request.duration_seconds_sum\",\n      \"deployment.environment.name\"=~\"$deployment_environment_name\",\n      \"service.namespace\"=~\"$service_namespace\",\n      \"service.name\"=\"$service_name\"\n    }[$__rate_interval]\n  )\n)\n/\navg by (\"deployment.environment.name\", \"service.namespace\", \"service.name\") (\n  rate(\n    {\"http.server.request.duration_seconds_count\",\n      \"deployment.environment.name\"=~\"$deployment_environment_name\",\n      \"service.namespace\"=~\"$service_namespace\",\n      \"service.name\"=\"$service_name\"\n    }[$__rate_interval]\n  )\n)",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "interval": "60s",
+              "legendFormat": "HTTP avg",
+              "range": true,
+              "refId": "HTTP AVG",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(\n  0.95,\n  sum by (le, \"deployment.environment.name\", \"service.namespace\", \"service.name\") (\n    rate(\n      {\"rpc.server.duration_milliseconds_bucket\",\n        \"deployment.environment.name\"=~\"$deployment_environment_name\",\n        \"service.namespace\"=~\"$service_namespace\",\n        \"service.name\"=\"$service_name\"\n      }[$__rate_interval]\n    ) / 1000\n  )\n)",
+              "hide": false,
+              "instant": false,
+              "interval": "60",
+              "legendFormat": "RPC p95",
+              "range": true,
+              "refId": "RPC P95"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "avg by (\"deployment.environment.name\", \"service.namespace\", \"service.name\") (\n  rate(\n    {\"rpc.server.duration_milliseconds_sum\",\n      \"deployment.environment.name\"=~\"$deployment_environment_name\",\n      \"service.namespace\"=~\"$service_namespace\",\n      \"service.name\"=\"$service_name\"\n    }[$__rate_interval]\n  ) / 1000\n)\n/\navg by (\"deployment.environment.name\", \"service.namespace\", \"service.name\") (\n  rate(\n    {\"rpc.server.duration_milliseconds_count\",\n      \"deployment.environment.name\"=~\"$deployment_environment_name\",\n      \"service.namespace\"=~\"$service_namespace\",\n      \"service.name\"=\"$service_name\"\n    }[$__rate_interval]\n  )\n)",
+              "hide": false,
+              "instant": false,
+              "interval": "60",
+              "legendFormat": "RPC avg",
+              "range": true,
+              "refId": "RPC AVG"
+            }
+          ],
+          "title": "Duration",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "HTTP and RPC endpoints aggregation on the `http.server.request.duration` and `rpc.server.duration` metrics. \n\nErrors are identified by : \n* `http.response.status_code=~\"5..\"`\n* `rpc.grpc.status_code!=\"0\"`\n\nSee https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration\n",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 100,
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "noValue": "No HTTP or RPC operation",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 5,
+            "y": 3
+          },
+          "id": 18,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "(\n    (sum by(\"deployment.environment.name\", \"service.namespace\", \"service.name\") (rate({\"http.server.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\", \"http.response.status_code\"=~\"5..\"}[$__rate_interval])) * 100) \n    / \n    sum by(\"deployment.environment.name\", \"service.namespace\", \"service.name\") (rate({\"http.server.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]))\n)\nor\n(\n    0\n    * \n    sum by(\"deployment.environment.name\", \"service.namespace\", \"service.name\") (rate({\"http.server.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]))\n)",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "interval": "60s",
+              "legendFormat": "HTTP 5xx errors",
+              "range": true,
+              "refId": "HTTP 5xx",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "((sum without (\"rpc.grpc.status_code\", instance) (rate({\"rpc.server.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\", \"rpc.grpc.status_code\"!=\"0\"}[$__rate_interval])) * 100) / sum without (\"rpc.grpc.status_code\", instance) (rate({\"rpc.server.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval])))\nor\n(0 * sum without (\"rpc.grpc.status_code\", instance) (rate({\"rpc.server.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval])))",
+              "hide": false,
+              "instant": false,
+              "interval": "60",
+              "legendFormat": "RPC errors",
+              "range": true,
+              "refId": "RPC Err"
+            }
+          ],
+          "title": "Error",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "HTTP & RPC endpoints aggregation on the `http.server.request.duration` & `rpc.server.duration` metrics.\n\nSee https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMin": 0,
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "log": 10,
+                  "type": "log"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "noValue": "No HTTP or RPC operation",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 10,
+            "y": 3
+          },
+          "id": 19,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "(sum(rate({\"http.server.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval])) by (\"deployment.environment.name\", \"service.namespace\", \"service.name\")) ",
+              "hide": false,
+              "instant": false,
+              "interval": "60s",
+              "legendFormat": "HTTP requests",
+              "range": true,
+              "refId": "HTTP RPS"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "(sum(rate({\"rpc.server.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval])) by (\"deployment.environment.name\", \"service.namespace\", \"service.name\")) * $__interval_ms / 1000",
+              "hide": false,
+              "instant": false,
+              "interval": "60",
+              "legendFormat": "RPC requests",
+              "range": true,
+              "refId": "RPC RPS"
+            }
+          ],
+          "title": "Request Rate",
+          "type": "timeseries"
+        },
+        {
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 9,
+            "x": 15,
+            "y": 3
+          },
+          "id": 40,
+          "options": {
+            "alertInstanceLabelFilter": "{\"service.name\"=\"$service_name\", \"service.namespace\"=\"$service_namespace\"}",
+            "alertName": "",
+            "dashboardAlerts": false,
+            "groupBy": [],
+            "groupMode": "default",
+            "maxItems": 20,
+            "showInactiveAlerts": false,
+            "sortOrder": 1,
+            "stateFilter": {
+              "error": true,
+              "firing": true,
+              "noData": false,
+              "normal": false,
+              "pending": true,
+              "recovering": true
+            },
+            "viewMode": "list"
+          },
+          "pluginVersion": "12.2.0",
+          "title": "Alerts",
+          "type": "alertlist"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Inbound HTTP operations of the service (aka HTTP endpoints) based on the `http.server.request.duration` metric.\n\nErrors are identified by `http.response.status_code=~\"5..\"`.\n\nSee https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "noValue": "No HTTP operation",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration (p99)"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "s"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "reqps"
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 219
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Error"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "id": 21,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Operation"
+              }
+            ]
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "\n        sum by (operation) (\n            label_join(\n                rate({\"http.server.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"operation\",\n                \" \",\n                \"http.request.method\",\n                \"http.route\"\n            )\n        )\n    ",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "interval": "60s",
+              "legendFormat": "{{operation}}",
+              "range": true,
+              "refId": "RPS",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "(\n        sum by (operation) (\n            label_join(\n                rate({\"http.server.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\", \"http.response.status_code\"=~\"5..\"}[$__rate_interval]),\n                \"operation\",\n                \" \",\n                \"http.request.method\",\n                \"http.route\"\n            )\n        )\n     / \n        sum by (operation) (\n            label_join(\n                rate({\"http.server.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"operation\",\n                \" \",\n                \"http.request.method\",\n                \"http.route\"\n            )\n        )\n    ) or (0 * \n        sum by (operation) (\n            label_join(\n                rate({\"http.server.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"operation\",\n                \" \",\n                \"http.request.method\",\n                \"http.route\"\n            )\n        )\n    )",
+              "hide": false,
+              "instant": false,
+              "interval": "60s",
+              "legendFormat": "{{operation}}",
+              "range": true,
+              "refId": "ERR_PCT"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "\n        histogram_quantile(\n            0.99,\n            sum by (le, operation) (\n                label_join(\n                rate({\"http.server.request.duration_seconds_bucket\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[5m]),\n                \"operation\",\n                \" \",\n                \"http.request.method\",\n                \"http.route\"\n                )\n            )\n        )\n    ",
+              "hide": false,
+              "instant": false,
+              "interval": "60s",
+              "legendFormat": "{{operation}}",
+              "range": true,
+              "refId": "Duration"
+            }
+          ],
+          "title": "HTTP Operations",
+          "transformations": [
+            {
+              "id": "timeSeriesTable",
+              "options": {
+                "Duration": {
+                  "timeField": "Time"
+                },
+                "ERR_PCT": {
+                  "timeField": "Time"
+                },
+                "RPS": {
+                  "timeField": "Time"
+                }
+              }
+            },
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "operation",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "includeByName": {},
+                "indexByName": {
+                  "Trend #Duration": 1,
+                  "Trend #ERR_PCT": 2,
+                  "Trend #RPS": 3,
+                  "operation": 0
+                },
+                "renameByName": {
+                  "Trend #Duration": "Duration (p99)",
+                  "Trend #ERR_PCT": "Error",
+                  "Trend #RPS": "Rate",
+                  "operation": "Operation"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Inbound gRPC operations of the service (aka gRPC endpoints) based on the `rpc.server.request.duration` metric.\n\nErrors are identified by `rpc.grpc.status_code != 0` which make the panel specific to the gRPC protocol.\n\nhttps://opentelemetry.io/docs/specs/semconv/rpc/rpc-metrics/#metric-rpcserverduration",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "noValue": "No RPC operation",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration (p99)"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "ms"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "reqps"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Error"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "id": 27,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Operation"
+              }
+            ]
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "\nsum by (operation) (\n    label_join(\n        rate({\"rpc.server.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n        \"operation\",\n        \"/\",\n        \"rpc.service\",\n        \"rpc.method\"\n    )\n)\n    ",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "interval": "60s",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "RPS",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "(\n        sum by (operation) (\n            label_join(\n                rate({\"rpc.server.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\", \"rpc.grpc.status_code\"!=\"0\"}[$__rate_interval]),\n                \"operation\",\n                \"/\",\n                \"rpc.service\",\n                \"rpc.method\"\n            )\n        )\n     / \n        sum by (operation) (\n            label_join(\n                rate({\"rpc.server.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"operation\",\n                \"/\",\n                \"rpc.service\",\n                \"rpc.method\"\n            )\n        )\n    ) or (0 * \n        sum by (operation) (\n            label_join(\n                rate({\"rpc.server.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"operation\",\n                \"/\",\n                \"rpc.service\",\n                \"rpc.method\"\n            )\n        )\n    )\n    ",
+              "hide": false,
+              "instant": false,
+              "interval": "60s",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "ERR_PCT"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "\n        histogram_quantile(\n            0.99,\n            sum by (le, operation) (\n                label_join(\n                rate({\"rpc.server.duration_milliseconds_bucket\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[5m]),\n                \"operation\",\n                \"/\",\n                \"rpc.service\",\n                \"rpc.method\"\n                )\n            )\n        )\n    ",
+              "hide": false,
+              "instant": false,
+              "interval": "60s",
+              "legendFormat": "{{operation}}",
+              "range": true,
+              "refId": "Duration"
+            }
+          ],
+          "title": "gRPC Operations",
+          "transformations": [
+            {
+              "id": "timeSeriesTable",
+              "options": {
+                "Duration": {
+                  "timeField": "Time"
+                },
+                "ERR_PCT": {
+                  "timeField": "Time"
+                },
+                "RPS": {
+                  "timeField": "Time"
+                }
+              }
+            },
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "operation",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "includeByName": {},
+                "indexByName": {
+                  "Trend #Duration": 1,
+                  "Trend #ERR_PCT": 2,
+                  "Trend #RPS": 3,
+                  "operation": 0
+                },
+                "renameByName": {
+                  "Trend #Duration": "Duration (p99)",
+                  "Trend #ERR_PCT": "Error",
+                  "Trend #RPS": "Rate",
+                  "operation": "Operation"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 15
+          },
+          "id": 28,
+          "panels": [],
+          "title": "Outbound Services and Databases",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "HTTP calls made by the service based on the `http.client.request.duration` metric.\n\nCalls broken done by remote `server.address` and by `http.request.method`.\n\nSee https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpclientrequestduration",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "noValue": "No HTTP call",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration (P99)"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "s"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "reqps"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Error"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "id": 23,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "\n        sum by (outbound_service) (\n            label_join(\n                rate({\"http.client.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"outbound_service\",\n                \" \",\n                \"server.address\",\n                \"http.request.method\",\n                \"url.template\"\n            )\n        )\n    ",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "interval": "60s",
+              "legendFormat": "{{server.address}} {{http.request.method}} {{url.template}}",
+              "range": true,
+              "refId": "RPS",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "(\n        sum by (outbound_service) (\n            label_join(\n                rate({\"http.client.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\", \"http.response.status_code\"=~\"5..\"}[$__rate_interval]),\n                \"outbound_service\",\n                \" \",\n                \"server.address\",\n                \"http.request.method\",\n                \"url.template\"\n            )\n        )\n     / \n        sum by (outbound_service) (\n            label_join(\n                rate({\"http.client.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"outbound_service\",\n                \" \",\n                \"server.address\",\n                \"http.request.method\",\n                \"url.template\"\n            )\n        )\n    ) or (0 * \n        sum by (outbound_service) (\n            label_join(\n                rate({\"http.client.request.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"outbound_service\",\n                \" \",\n                \"server.address\",\n                \"http.request.method\",\n                \"url.template\"\n            )\n        )\n    )",
+              "hide": false,
+              "instant": false,
+              "interval": "60s",
+              "legendFormat": "{{server.address}} {{http.request.method}} {{url.template}}",
+              "range": true,
+              "refId": "ERR_PCT"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "\nhistogram_quantile(\n    0.99,\n    sum by (le, outbound_service) (\n        label_join(\n        rate({\"http.client.request.duration_seconds_bucket\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[5m]),\n        \"outbound_service\",\n        \" \",\n        \"server.address\",\n        \"http.request.method\",\n        \"url.template\"\n        )\n    )\n)",
+              "hide": false,
+              "instant": false,
+              "interval": "60s",
+              "legendFormat": "{{server.address}} {{http.request.method}} {{url.template}}",
+              "range": true,
+              "refId": "DURATION"
+            }
+          ],
+          "title": "Outbound HTTP Services",
+          "transformations": [
+            {
+              "id": "timeSeriesTable",
+              "options": {
+                "Duration": {
+                  "timeField": "Time"
+                },
+                "ERR_PCT": {
+                  "timeField": "Time"
+                },
+                "RPS": {
+                  "timeField": "Time"
+                }
+              }
+            },
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "outbound_service",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "includeByName": {},
+                "indexByName": {
+                  "Trend #DURATION": 1,
+                  "Trend #ERR_PCT": 2,
+                  "Trend #RPS": 3,
+                  "outbound_service": 0
+                },
+                "renameByName": {
+                  "Trend #DURATION": "Duration (P99)",
+                  "Trend #Duration": "Duration (p99)",
+                  "Trend #ERR_PCT": "Error",
+                  "Trend #RPS": "Rate",
+                  "operation": "Operation",
+                  "outbound_service": "Service"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "DB calls made by the service based on the `db.client.operation.duration` metric.\n\nCalls broken down by `server.address` and `db.namespace`.\n\nSee https://opentelemetry.io/docs/specs/semconv/database/database-metrics/#metric-dbclientoperationduration\n",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "noValue": "No database call",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration (P99)"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "s"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "reqps"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Error"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 24,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "sum by (database) (\n    label_join(\n        rate({\"db.client.operation.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n        \"database\",\n        \"/\",\n        \"server.address\",\n        \"db.namespace\"\n    )\n)\n    ",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "interval": "60s",
+              "legendFormat": "{{server.address}} {{db.namespace}}",
+              "range": true,
+              "refId": "RPS",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "(\n        sum by (database) (\n            label_join(\n                rate({\"db.client.operation.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\", \"http.response.status_code\"=~\"5..\"}[$__rate_interval]),\n                \"database\",\n                \"/\",\n                \"server.address\",\n                \"db.namespace\"\n            )\n        )\n     / \n        sum by (database) (\n            label_join(\n                rate({\"db.client.operation.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"database\",\n                \"/\",\n                \"server.address\",\n                \"db.namespace\"\n            )\n        )\n    ) or (0 * \n        sum by (database) (\n            label_join(\n                rate({\"db.client.operation.duration_seconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"database\",\n                \"/\",\n                \"server.address\",\n                \"db.namespace\"\n            )\n        )\n    )",
+              "hide": false,
+              "instant": false,
+              "interval": "60s",
+              "legendFormat": "{{server.address}} {{db.namespace}}",
+              "range": true,
+              "refId": "ERR_PCT"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "\nhistogram_quantile(\n    0.99,\n    sum by (le, database) (\n        label_join(\n        rate({\"db.client.operation.duration_seconds_bucket\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[5m]),\n            \"database\",\n            \"/\",\n            \"server.address\",\n            \"db.namespace\"\n        )\n    )\n)",
+              "hide": false,
+              "instant": false,
+              "interval": "60s",
+              "legendFormat": "{{server.address}} {{db.namespace}}",
+              "range": true,
+              "refId": "DURATION"
+            }
+          ],
+          "title": "Outbound Databases",
+          "transformations": [
+            {
+              "id": "timeSeriesTable",
+              "options": {
+                "DURATION": {
+                  "timeField": "Time"
+                },
+                "Duration": {
+                  "timeField": "Time"
+                },
+                "ERR_PCT": {
+                  "timeField": "Time"
+                },
+                "RPS": {
+                  "timeField": "Time"
+                }
+              }
+            },
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "database",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "includeByName": {},
+                "indexByName": {
+                  "Trend #DURATION": 1,
+                  "Trend #ERR_PCT": 2,
+                  "Trend #RPS": 3,
+                  "database": 0
+                },
+                "renameByName": {
+                  "Trend #DURATION": "Duration (P99)",
+                  "Trend #Duration": "Duration (p99)",
+                  "Trend #ERR_PCT": "Error",
+                  "Trend #RPS": "Rate",
+                  "database": "Database",
+                  "database_operation": "Database Operation",
+                  "operation": "Operation",
+                  "outbound_service": "Service"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "gRPC calls made by the service based on the `rpc.client.request.duration` metric.\n\nSpecific to gRPC due to the usage of the `grpc.status.code` attribute to identify errors.\n\nCalls broken down by `server.address`, `rpc.service`, and `rpc.method`.\n\nSee https://opentelemetry.io/docs/specs/semconv/rpc/rpc-metrics/#rpc-client\n\n",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "noValue": "No RPC call",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Duration (P99)"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "ms"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "reqps"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Error"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "id": 32,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "\n        sum by (outbound_service) (\n            label_join(\n                rate({\"rpc.client.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"outbound_service\",\n                \"/\",\n                \"server.address\",\n                \"rpc.service\",\n                \"rpc.method\"\n            )\n        )\n    ",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "interval": "60s",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "RPS",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "(\n        sum by (outbound_service) (\n            label_join(\n                rate({\"rpc.client.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\", \"http.response.status_code\"=~\"5..\"}[$__rate_interval]),\n                \"outbound_service\",\n                \"/\",\n                \"server.address\",\n                \"rpc.service\",\n                \"rpc.method\"\n            )\n        )\n     / \n        sum by (outbound_service) (\n            label_join(\n                rate({\"rpc.client.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"outbound_service\",\n                \"/\",\n                \"server.address\",\n                \"rpc.service\",\n                \"rpc.method\"\n            )\n        )\n    ) or (0 * \n        sum by (outbound_service) (\n            label_join(\n                rate({\"rpc.client.duration_milliseconds_count\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[$__rate_interval]),\n                \"outbound_service\",\n                \"/\",\n                \"server.address\",\n                \"rpc.service\",\n                \"rpc.method\"\n            )\n        )\n    )",
+              "hide": false,
+              "instant": false,
+              "interval": "60s",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "ERR_PCT"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "\nhistogram_quantile(\n    0.99,\n    sum by (le, outbound_service) (\n        label_join(\n        rate({\"rpc.client.duration_milliseconds_bucket\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"service.namespace\"=~\"$service_namespace\", \"service.name\"=\"$service_name\"}[5m]),\n        \"outbound_service\",\n        \"/\",\n        \"server.address\",\n        \"rpc.service\",\n        \"rpc.method\"\n        )\n    )\n)",
+              "hide": false,
+              "instant": false,
+              "interval": "60s",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "DURATION"
+            }
+          ],
+          "title": "Outbound gRPC Services",
+          "transformations": [
+            {
+              "id": "timeSeriesTable",
+              "options": {
+                "Duration": {
+                  "timeField": "Time"
+                },
+                "ERR_PCT": {
+                  "timeField": "Time"
+                },
+                "RPS": {
+                  "timeField": "Time"
+                }
+              }
+            },
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "outbound_service",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "includeByName": {},
+                "indexByName": {
+                  "Trend #DURATION": 1,
+                  "Trend #ERR_PCT": 2,
+                  "Trend #RPS": 3,
+                  "outbound_service": 0
+                },
+                "renameByName": {
+                  "Trend #DURATION": "Duration (P99)",
+                  "Trend #Duration": "Duration (p99)",
+                  "Trend #ERR_PCT": "Error",
+                  "Trend #RPS": "Rate",
+                  "operation": "Operation",
+                  "outbound_service": "Service Method"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 26
+          },
+          "id": 42,
+          "panels": [],
+          "title": "Infrastructure (kube-prometheus-stack)",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Pod CPU and memory usage from kube-prometheus-stack (cAdvisor metrics). Filtered by K8s namespace ($service_namespace) and pods matching the selected service name ($service_name).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "CPU Usage"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Memory"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "decbytes"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 27
+          },
+          "id": 41,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "CPU Usage"
+              }
+            ]
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by (pod) (\n  rate(container_cpu_usage_seconds_total{\n    namespace=~\"$service_namespace\",\n    container!=\"\",\n    image!=\"\",\n    pod=~\".*${service_name}.*\"\n  }[$__rate_interval])\n)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "cpu"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by (pod) (\n  container_memory_working_set_bytes{\n    namespace=~\"$service_namespace\",\n    container!=\"\",\n    image!=\"\",\n    pod=~\".*${service_name}.*\"\n  }\n)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "mem"
+            }
+          ],
+          "title": "Pod Resources",
+          "transformations": [
+            {
+              "id": "timeSeriesTable",
+              "options": {
+                "cpu": {
+                  "timeField": "Time"
+                },
+                "mem": {
+                  "timeField": "Time"
+                }
+              }
+            },
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "pod",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "includeByName": {},
+                "indexByName": {},
+                "renameByName": {
+                  "Trend #cpu": "CPU Usage",
+                  "Trend #mem": "Memory",
+                  "pod": "Pod"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 33
+          },
+          "id": 25,
+          "panels": [],
+          "title": "Logs",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "elasticsearch"
+          },
+          "description": "Logs of the selected service from Elasticsearch, adapted from the upstream OpenSearch PPL query to ES|QL.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "noValue": "No application logs",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "@timestamp"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 226
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "severity_text"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 136
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "scope.name"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 246
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 15,
+            "w": 24,
+            "x": 0,
+            "y": 34
+          },
+          "id": 26,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "elasticsearch",
+                "uid": "elasticsearch"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "metrics": [
+                {
+                  "id": "1",
+                  "type": "logs"
+                }
+              ],
+              "query": "FROM $index\n| WHERE `service.name` == \"$service_name\" AND `service.namespace` == \"$service_namespace\"\n| KEEP `@timestamp`, severity_text, `body.text`, `scope.name`\n| SORT `@timestamp` DESC\n| LIMIT 200",
+              "queryType": "esql",
+              "refId": "A"
+            }
+          ],
+          "title": "",
+          "transformations": [
+            {
+              "id": "formatTime",
+              "options": {
+                "outputFormat": "YYYY-MM-DD HH:mm:ss.SSS",
+                "timeField": "@timestamp",
+                "timezone": "browser",
+                "useTimezone": true
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "includeByName": {},
+                "indexByName": {
+                  "@timestamp": 0,
+                  "body.text": 3,
+                  "scope.name": 2,
+                  "severity_text": 1
+                },
+                "renameByName": {
+                  "@timestamp": "Time",
+                  "body.text": "Message",
+                  "scope.name": "Logger",
+                  "severity_text": "Severity"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 49
+          },
+          "id": 29,
+          "panels": [],
+          "title": "Traces",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "description": "Recent traces for the selected service from Tempo, adapted from the upstream Jaeger-focused section to TraceQL.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "noValue": "No traces found",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "traceID"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 260
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "traceDuration"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 50
+          },
+          "id": 30,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Start Time"
+              }
+            ]
+          },
+          "pluginVersion": "12.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "tempo",
+                "uid": "tempo"
+              },
+              "filters": [],
+              "limit": 100,
+              "query": "{ resource.service.name = \"$service_name\" && resource.service.namespace = \"$service_namespace\" }",
+              "queryType": "traceql",
+              "refId": "A",
+              "tableType": "traces"
+            }
+          ],
+          "title": "",
+          "transformations": [
+            {
+              "id": "formatTime",
+              "options": {
+                "outputFormat": "YYYY-MM-DD HH:mm:ss.SSS",
+                "timeField": "startTime",
+                "timezone": "browser",
+                "useTimezone": true
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "nested": true
+                },
+                "includeByName": {},
+                "indexByName": {
+                  "startTime": 1,
+                  "traceDuration": 4,
+                  "traceID": 0,
+                  "traceName": 3,
+                  "traceService": 2
+                },
+                "renameByName": {
+                  "startTime": "Start Time",
+                  "traceDuration": "Duration",
+                  "traceID": "Trace ID",
+                  "traceName": "Root Span",
+                  "traceService": "Service"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "preload": false,
+      "refresh": "30s",
+      "schemaVersion": 42,
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "text": "prod",
+              "value": "prod"
+            },
+            "definition": "label_values(target_info, \"deployment.environment.name\")",
+            "description": "Deployment environment (`production`, `staging`...).\nResource attribute `deployment.environment.name` via `target_info`.\nValue `<<not defined>>` when the resource attribute `deployment.environment.name` is not set.",
+            "label": "Environment",
+            "name": "deployment_environment_name",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values(target_info, \"deployment.environment.name\")",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "staticOptions": [
+              {
+                "text": "<<not defined>>",
+                "value": ""
+              }
+            ],
+            "type": "query"
+          },
+          {
+            "allValue": ".*",
+            "allowCustomValue": false,
+            "current": {
+              "text": "e-commerce",
+              "value": "e-commerce"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "definition": "label_values(target_info{\"deployment.environment.name\"=~\"$deployment_environment_name\", \"telemetry.sdk.name\"=~\"\\\\S.*\"},\"service.namespace\")",
+            "description": "Service namespace.\nResource attribute `service.namespace` via `target_info`.\nValue `<<not defined>>` when the resource attribute `service.namespace` is not set.",
+            "includeAll": false,
+            "label": "Namespace",
+            "name": "service_namespace",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values(target_info{\"deployment.environment.name\"=~\"$deployment_environment_name\", \"telemetry.sdk.name\"=~\"\\\\S.*\"},\"service.namespace\")",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "sort": 1,
+            "staticOptions": [
+              {
+                "text": "<<not defined>>",
+                "value": ""
+              }
+            ],
+            "type": "query"
+          },
+          {
+            "current": {
+              "text": "frontend-service",
+              "value": "frontend-service"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "definition": "label_values(target_info{\"service.namespace\"=~\"$service_namespace\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"telemetry.sdk.name\"=~\"\\\\S.*\"},\"service.name\")",
+            "description": "Service name.\nResource attribute `service.name` via `target_info`.",
+            "label": "Service",
+            "name": "service_name",
+            "options": [],
+            "query": {
+              "qryType": 1,
+              "query": "label_values(target_info{\"service.namespace\"=~\"$service_namespace\", \"deployment.environment.name\"=~\"$deployment_environment_name\", \"telemetry.sdk.name\"=~\"\\\\S.*\"},\"service.name\")",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": {
+              "text": "otel",
+              "value": "otel"
+            },
+            "hide": 0,
+            "label": "Log Index",
+            "name": "index",
+            "options": [],
+            "query": "otel",
+            "skipUrlSync": false,
+            "type": "textbox"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "APM Dashboard - E-Commerce",
+      "uid": "e-commerce-apm",
+      "version": 1
+    }

--- a/kubernetes/apps/e-commerce/config/monitoring/grafana-dashboard.yaml
+++ b/kubernetes/apps/e-commerce/config/monitoring/grafana-dashboard.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: e-commerce-apm
+spec:
+  allowCrossNamespaceImport: true
+  folder: E-Commerce
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  configMapRef:
+    name: e-commerce-apm-dashboard
+    key: apm-dashboard.json

--- a/kubernetes/apps/e-commerce/config/monitoring/kustomization.yaml
+++ b/kubernetes/apps/e-commerce/config/monitoring/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: e-commerce
+
+configMapGenerator:
+  - name: e-commerce-apm-dashboard
+    files:
+      - apm-dashboard.json
+
+resources:
+  - grafana-dashboard.yaml

--- a/kubernetes/apps/e-commerce/config/monitoring/kustomization.yaml
+++ b/kubernetes/apps/e-commerce/config/monitoring/kustomization.yaml
@@ -3,10 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: e-commerce
 
-configMapGenerator:
-  - name: e-commerce-apm-dashboard
-    files:
-      - apm-dashboard.json
-
 resources:
   - grafana-dashboard.yaml

--- a/kubernetes/clusters/prod/apps/e-commerce-app.yaml
+++ b/kubernetes/clusters/prod/apps/e-commerce-app.yaml
@@ -123,3 +123,24 @@ spec:
     substituteFrom:
       - kind: ConfigMap
         name: cluster-settings
+
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: e-commerce-monitoring
+  namespace: flux-system
+spec:
+  interval: 30m
+  timeout: 5m
+  targetNamespace: e-commerce
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: grafana-operator-app
+    - name: opentelemetry-collector-app
+    - name: e-commerce-common
+  path: ./kubernetes/apps/e-commerce/config/monitoring
+  prune: true
+  wait: true

--- a/kubernetes/platform/flux-operator/instance/overlays/prod/values.yaml
+++ b/kubernetes/platform/flux-operator/instance/overlays/prod/values.yaml
@@ -3,7 +3,7 @@ instance:
   sync:
     kind: GitRepository
     url: https://github.com/ricsanfre/pi-cluster
-    ref: refs/heads/master
+    ref: refs/heads/feature/e-commerce-dashboard
     path: kubernetes/clusters/prod
     interval: 1h
     ignore: |

--- a/kubernetes/platform/flux-operator/instance/overlays/prod/values.yaml
+++ b/kubernetes/platform/flux-operator/instance/overlays/prod/values.yaml
@@ -3,7 +3,7 @@ instance:
   sync:
     kind: GitRepository
     url: https://github.com/ricsanfre/pi-cluster
-    ref: refs/heads/feature/e-commerce-dashboard
+    ref: refs/heads/master
     path: kubernetes/clusters/prod
     interval: 1h
     ignore: |

--- a/kubernetes/platform/opentelemetry-collector/app/base/values.yaml
+++ b/kubernetes/platform/opentelemetry-collector/app/base/values.yaml
@@ -60,10 +60,16 @@ config:
 
   processors:
     # Add stable service resource attributes derived from Kubernetes metadata.
+    # k8sattributes processor (enabled via kubernetesAttributes preset) provides
+    # k8s.namespace.name, k8s.pod.name, etc. — these are mapped to OTEL semantic
+    # conventions below.
     resource:
       attributes:
       - key: service.instance.id
         from_attribute: k8s.pod.uid
+        action: insert
+      - key: service.namespace
+        from_attribute: k8s.namespace.name
         action: insert
 
   # Spanmetrics Connector is a component in the OpenTelemetry Collector that allows you to derive metrics from span data. This is particularly useful when you have robust tracing but lack native metrics support in your language or framework.

--- a/kubernetes/platform/opentelemetry-collector/app/components/prometheus-exporter/values.yaml
+++ b/kubernetes/platform/opentelemetry-collector/app/components/prometheus-exporter/values.yaml
@@ -13,6 +13,6 @@ config:
     pipelines:
       metrics:
         receivers: [otlp, spanmetrics]
-        processors: [memory_limiter, resource, batch]
+        processors: [memory_limiter, k8sattributes, resource, batch]
         exporters: [otlphttp/prometheus]
 

--- a/kubernetes/platform/opentelemetry-collector/app/components/tempo-exporter/values.yaml
+++ b/kubernetes/platform/opentelemetry-collector/app/components/tempo-exporter/values.yaml
@@ -9,6 +9,6 @@ config:
   service:
     pipelines:
       traces:
-        processors: [memory_limiter, resource, batch]
+        processors: [memory_limiter, k8sattributes, resource, batch]
         exporters: [spanmetrics, otlp]
 

--- a/kubernetes/platform/opentelemetry-collector/app/overlays/dev/values.yaml
+++ b/kubernetes/platform/opentelemetry-collector/app/overlays/dev/values.yaml
@@ -1,1 +1,8 @@
 # opentelemetry-collector helm values (dev overlay)
+config:
+  processors:
+    resource:
+      attributes:
+      - key: deployment.environment.name
+        value: "dev"
+        action: insert

--- a/kubernetes/platform/opentelemetry-collector/app/overlays/prod/values.yaml
+++ b/kubernetes/platform/opentelemetry-collector/app/overlays/prod/values.yaml
@@ -1,1 +1,8 @@
 # opentelemetry-collector helm values (prod overlay)
+config:
+  processors:
+    resource:
+      attributes:
+      - key: deployment.environment.name
+        value: "prod"
+        action: insert


### PR DESCRIPTION
## Summary

Recover the old `opentelemetry-demo` APM dashboard (`apm-dashboard.json`) and adapt it for the current e-commerce microservices.

## Changes

### OTEL Collector pipeline fixes (5 files)
- Add `service.namespace` mapping (`k8s.namespace.name` → `service.namespace`) in the base resource processor
- Add `k8sattributes` processor to **metrics** and **traces** pipelines so Kubernetes metadata labels are available for mapping
- Set `deployment.environment.name` per overlay (`prod` / `dev`)

### New APM Dashboard (3 files)
- `kubernetes/apps/e-commerce/config/monitoring/` — GrafanaDashboard CR with inline JSON, deployed via Flux
- **UID**: `e-commerce-apm` | **Title**: "APM Dashboard - E-Commerce"
- Variables default to `e-commerce` namespace and `prod` environment
- Infrastructure panels replaced with kube-prometheus-stack cAdvisor metrics (`container_cpu_usage_seconds_total`, `container_memory_working_set_bytes`)
- ES queries use `$index` variable (default: `logs-*.otel-*`)
- gRPC panels preserved (degrade gracefully for HTTP-only services)
- Fixed `telemetry.sdk.name` filter — removed from variable queries since Node.js sets `process.runtime.name` instead

### Flux deployment
- New `e-commerce-monitoring` Kustomization in `e-commerce-app.yaml`

## Testing
- Dashboard deployed and verified in Grafana under **E-Commerce** folder
- All 8 services appear in the Service dropdown
- PromQL queries use dotted label syntax (`{"service.name"="value"}`) which works with Prometheus 3.x + `NoUTF8EscapingWithSuffixes` translation strategy